### PR TITLE
Fix t.object use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ const Category = t.recursion<ICategory>('Category', self => t.object({
 import * as t from 'io-ts'
 ```
 
-| Type | TypeScript syntax | Runtime type / combinator |
+| Type | TypeScript annotation syntax | Runtime type / combinator |
 |------|-------|-------------|
 | null | `null` | `t.null` |
 | undefined | `undefined` | `t.undefined` |
@@ -132,7 +132,7 @@ import * as t from 'io-ts'
 | maybe | `A | undefined | null` | `t.maybe(A)` |
 | mapping | `{ [key: A]: B }` | `t.mapping(A, B)` |
 | refinement | ✘ | `t.refinement(A, predicate)` |
-| object | `{ name: string }` | `t.object({ name: string })` |
+| object | `{ name: string }` | `t.object({ name: t.string })` |
 | tuple | `[A, B]` | `t.tuple([A, B])` |
 | union | `A | B` | `t.union([A, B])` |
 | intersection | `A & B` | `t.intersection([A, B])` |


### PR DESCRIPTION
Hi @gcanti, great idea and amazing work! 
Reading the docs, I think that I have spotted a simple typo in the t.object definition use-case, see the fix in this PR.
And also I suggest to use the "annotation" specification in the header of the Typescript syntax, and maybe it can be completed adding a ":" in front of all the rows in the table (in that column) I don't know what you think about it...