### PR TITLE
Add list of community build error reporters to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ ThrowReporter.report(validation)
 // => throws 'Invalid value undefined supplied to : { name: string, age: number }/age: number'
 ```
 
+## Community error reporters
+
+- [io-ts-reporters](https://github.com/OliverJAsh/io-ts-reporters)
+
 # TypeScript integration
 
 Runtime types can be inspected


### PR DESCRIPTION
I built an error reporter for a project of mine and published it to npm. https://github.com/OliverJAsh/io-ts-reporters

What do you think about including a list of community built error reporters in the README or in the wiki?

Thanks!