### PR TITLE
Tagged Union of Types, closes #50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.log
 node_modules
 lib
-lib-jsnext
 dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 **Note**: Gaps between patch versions are faulty/broken releases.
 **Note**: A feature tagged as Experimental is in a high state of flux, you're at risk of it changing without notice.
 
+# 0.5.0
+
+- **Breaking Change**
+  - `Type` is now an interface
+  - types no more own a `is` method, use `t.is` instead
+  - unions no more own a `fold` method
+  - `Reporter`, `PathReporter`, `ThrowReporter` are now top level modules
+
 # 0.4.0
 
 - **Breaking Change**

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 A value of type `Type<T>` (called "runtime type") is the runtime representation of the static type `T`:
 
 ```js
-class Type<T> {
-  constructor(public readonly name: string, public readonly validate: Validate<T>) {}
-  is(x: any): x is T
+export interface Type<A> {
+  readonly _A: A
+  readonly name: string
+  readonly validate: Validate<A>
 }
 ```
 
@@ -24,11 +25,14 @@ A runtime type representing `string` can be defined as
 ```js
 import * as t from 'io-ts'
 
-const string = new t.Type<string>(
-  'string',
-  (value, context) => typeof value === 'string' ? t.success(v) : t.failure<string>(v, c)
-)
+export const string: t.Type<string> = {
+  _A: t._A,
+  name: 'string',
+  validate: (value, context) => (typeof value === 'string' ? t.success(value) : t.failure<string>(value, context))
+}
 ```
+
+Note: The `_A` field contains a dummy value and is useful to extract a static type from the runtime type (see the section "TypeScript integration" below)
 
 A runtime type can be used to validate an object in memory (for example an API payload)
 
@@ -63,7 +67,8 @@ This package exports two default reporters
 Example
 
 ```js
-import { PathReporter, ThrowReporter } from 'io-ts/lib/reporters/default'
+import { PathReporter } from 'io-ts/lib/PathReporter'
+import { ThrowReporter } from 'io-ts/lib/ThrowReporter'
 
 const validation = t.validate({"name":"Giulio"}, Person)
 
@@ -111,10 +116,12 @@ type ICategory = {
   categories: Array<ICategory>
 }
 
-const Category = t.recursion<ICategory>('Category', self => t.object({
-  name: t.string,
-  categories: t.array(self)
-}))
+const Category = t.recursion<ICategory>('Category', self =>
+  t.interface({
+    name: t.string,
+    categories: t.array(self)
+  })
+)
 ```
 
 # Implemented types / combinators
@@ -185,13 +192,15 @@ You can define your own types. Let's see an example
 import * as t from 'io-ts'
 
 // returns a Date from an ISO string
-const DateFromString = new t.Type<Date>(
-  'DateFromString',
-  (v, c) => t.string.validate(v, c).chain(s => {
-    const d = new Date(s)
-    return isNaN(d.getTime()) ? t.failure<Date>(s, c) : t.success(d)
-  })
-)
+const DateFromString: t.Type<Date> = {
+  _A: t._A,
+  name: 'DateFromString',
+  validate: (v, c) =>
+    t.string.validate(v, c).chain(s => {
+      const d = new Date(s)
+      return isNaN(d.getTime()) ? t.failure<Date>(s, c) : t.success(d)
+    })
+}
 
 const s = new Date(1973, 10, 30).toISOString()
 
@@ -202,7 +211,7 @@ t.validate('foo', DateFromString)
 // => Left( 'Invalid value "foo" supplied to : DateFromString' )
 ```
 
-Note that you can **deserializing** while validating.
+Note that you can **deserialize** while validating.
 
 # Custom combinators
 
@@ -211,7 +220,10 @@ You can define your own combinators. Let's see some examples
 ## The `maybe` combinator
 
 ```ts
-export function maybe<RT extends t.Any>(type: RT, name?: string): t.UnionType<[RT, typeof t.null], t.TypeOf<RT> | null> {
+export function maybe<RT extends t.Any>(
+  type: RT,
+  name?: string
+): t.UnionType<[RT, typeof t.null], t.TypeOf<RT> | null> {
   return t.union([type, t.null], name)
 }
 ```
@@ -260,7 +272,7 @@ const Payload2 = t.interface({
 
 // narrowed types
 function convertFtoC(fahrenheit: FahrenheitT): CelsiusT {
-  return (fahrenheit - 32) / 1.8 as CelsiusT;
+  return ((fahrenheit - 32) / 1.8) as CelsiusT
 }
 
 console.log(t.validate(payload, Payload2).map(x => convertFtoC(x.celsius))) // error: Type '"Celsius"' is not assignable to type '"Fahrenheit"'
@@ -275,15 +287,13 @@ No, however you can define your own logic for that (if you *really* trust the in
 
 ```ts
 import * as t from 'io-ts'
-import { pathReporterFailure } from 'io-ts/lib/reporters/default'
+import { failure } from 'io-ts/lib/PathReporter'
 
 function unsafeValidate<T>(value: any, type: t.Type<T>): T {
   if (process.env.NODE_ENV !== 'production') {
-    return t.validate(value, type)
-      .fold(
-        errors => { throw new Error(pathReporterFailure(errors).join('\n')) },
-        x => x
-      )
+    return t.validate(value, type).fold(errors => {
+      throw new Error(failure(errors).join('\n'))
+    }, x => x)
   }
   return value as T
 }
@@ -306,7 +316,7 @@ Hover on NestedInterfaceType will display
 
 type NestedInterfaceType = {
   foo: t.InterfaceOf<{
-    bar: t.Type<string>;
+    bar: t.StringType;
   }>;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript compatible runtime type system for IO validation",
   "files": [
     "lib"

--- a/src/PathReporter.ts
+++ b/src/PathReporter.ts
@@ -1,6 +1,5 @@
 import { Reporter } from './Reporter'
-import { isLeft } from 'fp-ts/lib/Either'
-import { Context, getFunctionName, ValidationError } from '../index'
+import { Context, getFunctionName, ValidationError } from './index'
 
 function stringify(value: any): string {
   return typeof value === 'function' ? getFunctionName(value) : JSON.stringify(value)
@@ -14,18 +13,14 @@ function getMessage(value: any, context: Context): string {
   return `Invalid value ${stringify(value)} supplied to ${getContextPath(context)}`
 }
 
-export function pathReporterFailure(es: Array<ValidationError>): Array<string> {
+export function failure(es: Array<ValidationError>): Array<string> {
   return es.map(e => getMessage(e.value, e.context))
 }
 
-export const PathReporter: Reporter<Array<string>> = {
-  report: validation => validation.fold(pathReporterFailure, () => ['No errors!'])
+export function success(): Array<string> {
+  return ['No errors!']
 }
 
-export const ThrowReporter: Reporter<void> = {
-  report: validation => {
-    if (isLeft(validation)) {
-      throw PathReporter.report(validation).join('\n')
-    }
-  }
+export const PathReporter: Reporter<Array<string>> = {
+  report: validation => validation.fold(failure, success)
 }

--- a/src/Reporter.ts
+++ b/src/Reporter.ts
@@ -1,4 +1,4 @@
-import { Validation } from '../index'
+import { Validation } from './index'
 
 export interface Reporter<A> {
   report: (validation: Validation<any>) => A

--- a/src/ThrowReporter.ts
+++ b/src/ThrowReporter.ts
@@ -1,0 +1,11 @@
+import { Reporter } from './Reporter'
+import { isLeft } from 'fp-ts/lib/Either'
+import { PathReporter } from './PathReporter'
+
+export const ThrowReporter: Reporter<void> = {
+  report: validation => {
+    if (isLeft(validation)) {
+      throw PathReporter.report(validation).join('\n')
+    }
+  }
+}

--- a/test/Type.ts
+++ b/test/Type.ts
@@ -4,7 +4,7 @@ import * as t from '../src/index'
 describe('Type', () => {
   it('is', () => {
     const T = t.string
-    assert.strictEqual(T.is('s'), true)
-    assert.strictEqual(T.is(1), false)
+    assert.strictEqual(t.is('s', T), true)
+    assert.strictEqual(t.is(1, T), false)
   })
 })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,28 +1,27 @@
 import * as assert from 'assert'
 import { isRight, isLeft } from 'fp-ts/lib/Either'
-import { Validation, Type } from '../src/index'
 import * as t from '../src/index'
-import { PathReporter } from '../src/reporters/default'
+import { PathReporter } from '../src/PathReporter'
 
 export function identity<A>(a: A): A {
   return a
 }
 
-export function assertSuccess<T>(validation: Validation<T>): void {
+export function assertSuccess<T>(validation: t.Validation<T>): void {
   assert.ok(isRight(validation))
 }
 
-export function assertFailure<T>(validation: Validation<T>, descriptions: Array<string>): void {
+export function assertFailure<T>(validation: t.Validation<T>, descriptions: Array<string>): void {
   assert.ok(isLeft(validation))
   assert.deepEqual(PathReporter.report(validation), descriptions)
 }
 
-export function assertStrictEqual<T>(validation: Validation<T>, value: any): void {
+export function assertStrictEqual<T>(validation: t.Validation<T>, value: any): void {
   assert.strictEqual(validation.fold<any>(identity, identity), value)
 }
 
-export function assertDeepEqual<T>(validation: Validation<T>, value: any): void {
+export function assertDeepEqual<T>(validation: t.Validation<T>, value: any): void {
   assert.deepEqual(validation.fold<any>(identity, identity), value)
 }
 
-export const number2 = new Type<number>('number2', (v, c) => t.number.validate(v, c).map(n => n * 2))
+export const number2 = t.mapWithName(n => n * 2, t.number, 'number2')

--- a/test/union.ts
+++ b/test/union.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert'
+// import * as assert from 'assert'
 import * as t from '../src/index'
 import { assertSuccess, assertFailure, assertStrictEqual } from './helpers'
 
@@ -18,11 +18,5 @@ describe('union', () => {
   it('should fail validating an invalid value', () => {
     const T = t.union([t.string, t.number])
     assertFailure(t.validate(true, T), ['Invalid value true supplied to : (string | number)'])
-  })
-
-  it('should have a fold method', () => {
-    const T = t.union([t.string, t.number])
-    const f = T.fold(s => s.length, n => n)
-    assert.strictEqual(f('hello'), 5)
   })
 })

--- a/typings-checker/index.ts
+++ b/typings-checker/index.ts
@@ -146,16 +146,6 @@ x27[0] = 2
 x27.push(2)
 
 //
-// fold on unions
-//
-
-const f1 = t.union([t.string, t.number]).fold(s => s.length, n => n)
-f1('a')
-f1(1)
-// $ExpectError Argument of type 'true' is not assignable to parameter of type 'string | number'
-f1(true)
-
-//
 // map
 //
 


### PR DESCRIPTION
This PR moves `io-ts` to structural typing removing all `class`es. Here's the list of breaking changes so far

- `Type` is now an interface
- types no more own a `is` method, use `t.is` instead
- unions no more own a `fold` method
- `Reporter`, `PathReporter`, `ThrowReporter` are now top level modules

@justinwoo Could you please try it out? Does it break badly some of your code?

`lib` is committed in so you can install it by running

```
npm i gcanti/io-ts#50
```