### PR TITLE
README fixes and tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export const string: t.Type<string> = {
 }
 ```
 
-Note: The `_A` field contains a dummy value and is useful to extract a static type from the runtime type (see the section "TypeScript integration" below)
+Note: The `_A` field contains a dummy value and is useful to extract a static type from the runtime type (see the ["TypeScript integration"](#typescript-integration) section below)
 
 A runtime type can be used to validate an object in memory (for example an API payload)
 
@@ -140,23 +140,23 @@ import * as t from 'io-ts'
 | any | `any` | `t.any` |
 | never | `never` | `t.never` |
 | integer | ✘ | `t.Integer` |
-| generic array | `Array<any>` | `t.Array` |
-| generic dictionary | `{ [key: string]: any }` | `t.Dictionary` |
+| array of any | `Array<any>` | `t.Array` |
+| array of type | `Array<A>` | `t.array(A)` |
+| dictionary of any | `{ [key: string]: any }` | `t.Dictionary` |
+| dictionary of type | `{ [key: A]: B }` | `t.dictionary(A, B)` |
 | function | `Function` | `t.Function` |
-| arrays | `Array<A>` | `t.array(A)` |
 | literal | `'s'` | `t.literal('s')` |
-| maybe | `A | null` | `t.maybe(A)` |
 | partial | `Partial<{ name: string }>` | `t.partial({ name: t.string })` |
 | readonly | `Readonly<{ name: string }>` | `t.readonly({ name: t.string })` |
 | readonly array | `ReadonlyArray<number>` | `t.readonlyArray(t.number)` |
-| dictionaries | `{ [key: A]: B }` | `t.dictionary(A, B)` |
-| refinement | ✘ | `t.refinement(A, predicate)` |
-| interface | `{ name: string }` | `t.interface({ name: t.string })` |
-| tuple | `[A, B]` | `t.tuple([A, B])` |
-| union | `A \| B` | `t.union([A, B])` |
-| intersection | `A & B` | `t.intersection([A, B])` |
+| interface | `interface A { name: string }` | `t.interface({ name: t.string })` |
+| interface inheritance | `interface B extends A {}` | `t.intersection([ A, t.interface({}) ])` |
+| tuple | `[ A, B ]` | `t.tuple([ A, B ])` |
+| union | `A \| B` | `t.union([ A, B ])` |
+| intersection | `A & B` | `t.intersection([ A, B ])` |
 | keyof | `keyof M` | `t.keyof(M)` |
-| recursive types |  | `t.recursion(name, definition)` |
+| recursive types | see [TypeScript integration](#typescript-integration) | `t.recursion(name, definition)` |
+| refinement | ✘ | `t.refinement(A, predicate)` |
 | map | ✘ | `t.map(f, type)` |
 | prism | ✘ | `t.prism(type, getOption)` |
 
@@ -218,6 +218,8 @@ Note that you can **deserialize** while validating.
 You can define your own combinators. Let's see some examples
 
 ## The `maybe` combinator
+
+An equivalent to `T | null`
 
 ```ts
 export function maybe<RT extends t.Any>(

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ type IPerson = {
 }
 ```
 
+## Recursive types
+
 Note that recursive types can't be inferred
 
 ```js
@@ -155,7 +157,7 @@ import * as t from 'io-ts'
 | union | `A \| B` | `t.union([ A, B ])` |
 | intersection | `A & B` | `t.intersection([ A, B ])` |
 | keyof | `keyof M` | `t.keyof(M)` |
-| recursive types | see [TypeScript integration](#typescript-integration) | `t.recursion(name, definition)` |
+| recursive types | see [Recursive types](#recursive-types) | `t.recursion(name, definition)` |
 | refinement | ✘ | `t.refinement(A, predicate)` |
 | map | ✘ | `t.map(f, type)` |
 | prism | ✘ | `t.prism(type, getOption)` |


### PR DESCRIPTION
* Added a link to the "TypeScript integration" section.
* Reordered arrays, dictionaries to be grouped together.
* Removed `maybe`, it's no longer supplied (since 0.2.2).
* Added `interface inheritance`.
* Added a link to the "Recursive types" section to the recursive
types in the table (there is an example for `recursion`).
* Reordered `refinement` to the end, closer to other types unsupported
by TypeScript.
* Added explanation what is `maybe` in its example.

Refs https://github.com/gcanti/io-ts/issues/59