### PR TITLE
Make props indexable by string literals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -348,17 +348,17 @@ export function array<RT extends Any>(type: RT, name?: string): ArrayType<RT> {
 // interfaces
 //
 
-export type Props = { [key: string]: Any }
+export type Props<K extends string> = { [P in K]: Any }
 
 // TODO remove this once https://github.com/Microsoft/TypeScript/issues/14041 is fixed
-export type InterfaceOf<P extends Props> = { [K in keyof P]: TypeOf<P[K]> }
+export type InterfaceOf<P extends Props<any>> = { [K in keyof P]: TypeOf<P[K]> }
 
-export interface InterfaceType<P extends Props> extends Type<InterfaceOf<P>> {
+export interface InterfaceType<P extends Props<any>> extends Type<InterfaceOf<P>> {
   readonly _tag: 'InterfaceType'
   readonly props: P
 }
 
-export function _interface<P extends Props>(props: P, name?: string): InterfaceType<P> {
+export function _interface<P extends Props<string>>(props: P, name?: string): InterfaceType<P> {
   return {
     _A,
     _tag: 'InterfaceType',
@@ -391,19 +391,19 @@ export function _interface<P extends Props>(props: P, name?: string): InterfaceT
 //
 
 // TODO remove this once https://github.com/Microsoft/TypeScript/issues/14041 is fixed
-export type PartialOf<P extends Props> = { [K in keyof P]?: TypeOf<P[K]> }
+export type PartialOf<P extends Props<any>> = { [K in keyof P]?: TypeOf<P[K]> }
 // TODO remove this once https://github.com/Microsoft/TypeScript/issues/14041 is fixed
-export type PartialPropsOf<P extends Props> = {
+export type PartialPropsOf<P extends Props<any>> = {
   [K in keyof P]: UnionType<[P[K], Type<undefined>], [TypeOf<P[K]>, undefined]>
 }
 
-export interface PartialType<P extends Props> extends Type<PartialOf<P>> {
+export interface PartialType<P extends Props<any>> extends Type<PartialOf<P>> {
   readonly _tag: 'PartialType'
   readonly props: PartialPropsOf<P>
 }
 
-export function partial<P extends Props>(props: P, name?: string): PartialType<P> {
-  const partials: Props = {}
+export function partial<P extends Props<string>>(props: P, name?: string): PartialType<P> {
+  const partials: Props<string> = {}
   for (let k in props) {
     partials[k] = union([props[k], undefinedType])
   }


### PR DESCRIPTION
Running across a problem where I'm trying to give better names (via interfaces) to some types. Typescript complains of lacking an index signature due to the definition of Props.

I'm using `io-ts` to generate database schemas and some other stuff.

```typescript
export type AllowedValueTypes =
  | t.BooleanType
  | t.NumberType
  | t.StringType
  | t.AnyDictionaryType
  | DateType
  | TextType
  | t.UnionType<[t.LiteralType<string>]>
  | ForeignKeyType<Sequelize.Model<any, any>>

export type ObjectOverwritePartial<T, K extends keyof T> = ObjectOverwrite<T, Partial<Pick<T, K>>>
type SInterface = t.InterfaceType<{ [key: string]: AllowedValueTypes }>

interface DefineModel {
  <
    R extends SInterface,
    T extends t.TypeOf<R> = t.TypeOf<R>,
    D extends keyof T = keyof T
  >(
    type: R,
    options: SequelizeOptions<T>,
    defaultValues: { [K in D]: T[K] },
  ): Sequelize.Model<WithId<T>, ObjectOverwritePartial<T, D>>

  <R extends SInterface<any>, T extends t.TypeOf<R> = t.TypeOf<R>>(
    type: R,
    options?: SequelizeOptions<T>,
  ): Sequelize.Model<WithId<T>, T>
}

export const defineModel: DefineModel = (_: any) => null as any

const _AuditLog = t.interface(
  {
    changes: t.Dictionary,
    projectId: ForeignKeyType(ProjectModel),
    siteId: ForeignKeyType(SiteModel),
    userId: ForeignKeyType(UserModel),
  },
  'AuditLog',
)

export interface AuditLog extends t.TypeOf<typeof _AuditLog> {}

export interface AuditLogType extends Identity<typeof _AuditLog> {
  _A: AuditLog
}
export const AuditLog: AuditLogType = _AuditLog

export const AuditLogModel = defineModel(
  AuditLog, // Err see below
  {
    timestamps: true,
    updatedAt: false,
  },
  { projectId: 3 }
)
```
```
[ts]
Argument of type 'AuditLogType' is not assignable to parameter of type 'InterfaceType<{ [key: string]: AllowedValueTypes; }>'.
  Types of property '_A' are incompatible.
    Type 'AuditLog' is not assignable to type 'InterfaceOf<{ [key: string]: AllowedValueTypes; }>'.
      Index signature is missing in type 'AuditLog'.
```

One way to solve this is to remove the AuditLogType and AuditLog bits but then the inferred type signatures become extremely huge and unwieldy.

Or as the pull request shows, you can allow props to track its fields and adjust a few lines.

```typescript
type SInterface<K extends string> = t.InterfaceType<{ [P in K]: AllowedValueTypes }>
interface DefineModel {
  <
    R extends SInterface<any>,
    T extends t.TypeOf<R> = t.TypeOf<R>,
    D extends keyof T = keyof T
  >(
    type: R,
    options: SequelizeOptions<T>,
    defaultValues: { [K in D]: T[K] },
  ): Sequelize.Model<WithId<T>, ObjectOverwritePartial<T, D>>

  <R extends SInterface<any>, T extends t.TypeOf<R> = t.TypeOf<R>>(
    type: R,
    options?: SequelizeOptions<T>,
  ): Sequelize.Model<WithId<T>, T>
}
```

and it works just fine.

What do you think?

