### PR TITLE
docs: cache NODE_ENV in unsafe validate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,10 @@ No, however you can define your own logic for that (if you _really_ trust the in
 import * as t from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
 
+const { NODE_ENV } = process.env
+
 export function unsafeValidate<S, A>(value: any, type: t.Type<S, A>): A {
-  if (process.env.NODE_ENV !== 'production') {
+  if (NODE_ENV !== 'production') {
     return t.validate(value, type).fold(errors => {
       throw new Error(failure(errors).join('\n'))
     }, t.identity)


### PR DESCRIPTION
Just a small documentation update, if you're open to it. Suggesting that `NODE_ENV` be "cached" in the example `unsafeValidate` method.

Reasoning / discussions here:
* https://github.com/nodejs/node/issues/3104
* https://github.com/nodejs/node/pull/1648

Unless you'd expect `NODE_ENV` to be editable while the application is running (debugging on a live server, perhaps?)