### PR TITLE
Add tagged union case to flow-tests.js

### DIFF
--- a/flow-tests.js
+++ b/flow-tests.js
@@ -29,6 +29,34 @@ const l1: L1T = 'foo'
 // $FlowFixMe
 const l2: L1T = 'bar'
 
+function testLiteralAsTagInUnion() {
+  // Note that `t.literal(('foo': 'foo'))` does not work for this use case
+  const Foo = t.type({
+    type: (t.literal('foo'): t.Type<*, 'foo'>),
+    foo: t.string
+  })
+  const Bar = t.type({
+    type: (t.literal('bar'): t.Type<*, 'bar'>),
+    bar: t.number
+  })
+  const FooOrBar = t.union([Foo, Bar])
+  type FooOrBarT = t.TypeOf<typeof FooOrBar>
+
+  // only passes type-checking if tag-based refinement works
+  function getFoo(x: FooOrBarT): ?string {
+    if (x.type === 'foo') {
+      return x.foo
+    }
+  }
+}
+
+function testLiteralMismatch() {
+  const LiteralMismatch = t.type({
+    // $FlowFixMe
+    type: (t.literal('sometag'): t.Type<*, 'differenttag'>)
+  })
+}
+
 //
 // keyof
 //


### PR DESCRIPTION
I'm thinking of rewriting a blog post to use io-ts to define types: http://sitr.us/2016/12/20/flow-cookbook-unpacking-json.html

I've been updating my code, and in particular testing tagged unions - where a union type can be refined by testing the value of a `type` property, or some other distinguishing property. I have found that this works well with io-ts with two caveats:

In an existing test I saw a literal type like this: `t.literal(('foo': 'foo'))`. Unfortunately that does not work when the literal type is a property inside a `t.type` type because Flow generalizes literal types when they flow through polymorphic code to (e.g. `'foo'` changes to `string`). But this form does work:

```js
  const Foo = t.type({
    type: (t.literal('foo'): t.Type<*, 'foo'>),
    foo: t.string
  })
```

The other issue is that refinement breaks down when a `t.partial` type is included in the mix. The problem is that Flow makes few assumptions about what `$Shape<T>` might resolve to. As far as Flow is concerned, a type produced by `t.partial` might end up as an object type with a conflicting `type` property.  For example:

```js
function testTaggedUnionOfIntersections() {
  const Foo = t.intersection([
    t.type({
      type: (t.literal('foo'): t.Type<*, 'foo'>),
      foo: t.string
    }),
    t.partial({
      optionalProp: t.string
    })
  ])
  const Bar = t.intersection([
    t.type({
      type: (t.literal('bar'): t.Type<*, 'bar'>),
      bar: t.number
    }),
    t.partial({
      optionalProp: t.string
    })
  ])
  const FooOrBar = t.union([Foo, Bar])
  type FooOrBarT = t.TypeOf<typeof FooOrBar>

  function getFoo(x: FooOrBarT): ?string {
    if (x.type === 'foo') {
      // $FlowFixMe: we would like this to type-check, but it does not
      return x.foo
    }
  }
}
```

So the procedure that is recommended in the documentation for encoding optional properties (an intersection of `t.type` and `t.partial`) does not work well using tagged unions in Flow. And I think that the use of `$Shape<T>` is likely to lead to other problems.

What does work well is to use encode optional properties using a maybe-undefined type. I'm using this combinator in my testing:

```js
function optional<T>(
  type: t.Type<any, T>,
  name?: string
): t.Type<any, T | void> {
  return new t.Type(
    /* name */     name || `${type.name} | void`,
    /* isA  */     v => typeof v === 'undefined',
    /* validate */ (s, context) => {
      if (typeof s === 'undefined') {
        return t.success(s)
      }
      else {
        const result = t.validate(s, type)
        return result.map(v => v)
        // TODO: `map` transforms `Validation<T>` to `Validation<T | void>`
      }
    },
    /* serialize */ v => v
  )
}
```

And then it is used like this:

```js
  const Foo = t.type({
    type: (t.literal('foo'): t.Type<*, 'foo'>),
    foo: t.string,
    optionalProp: optional(t.string)
  })
  const Bar = t.type({
    type: (t.literal('bar'): t.Type<*, 'bar'>),
    bar: t.number,
    optionalProp: optional(t.string)
  })
```

I think it would be quite handy to have something like `optional` built in!

I realize that this pattern leads to a mismatch between the type and the runtime value: the type assumes that the property is present with a possibly undefined value, but the property might be completely absent at runtime. I think that is likely ok in most cases. But a workaround could be to modify the `t.type` validation to add the property if it is absent (with an undefined value).