### PR TITLE
Various optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "8"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "prettier --no-semi --single-quote --print-width 120 --parser flow --write \"{src,test,examples,exercises}/**/*.js.flow\"",
     "test": "npm run prettier && npm run lint && npm run typings-checker && npm run mocha",
     "clean": "rm -rf lib/*",
-    "build": "npm run clean && tsc && npm run flow-copy-definition-files"
+    "build": "npm run clean && tsc && npm run flow-copy-definition-files",
+    "perf": "node perf/index"
   },
   "repository": {
     "type": "git",
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@types/mocha": "2.2.38",
     "@types/node": "7.0.4",
+    "benchmark": "2.1.4",
     "mocha": "3.2.0",
     "prettier": "1.8.2",
     "ts-node": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "fp-ts": "^0.6.4"
   },
   "devDependencies": {
+    "@types/benchmark": "1.0.31",
     "@types/mocha": "2.2.38",
     "@types/node": "7.0.4",
     "benchmark": "2.1.4",

--- a/perf/index.js
+++ b/perf/index.js
@@ -1,0 +1,28 @@
+var Benchmark = require('benchmark')
+var t = require('../lib/index')
+
+const suite = new Benchmark.Suite()
+
+const T = t.type({
+  a: t.string,
+  b: t.number,
+  c: t.array(t.boolean),
+  d: t.tuple([t.number, t.string])
+})
+const payloadKO = { c: [1], d: ['foo'] }
+const payloadOK = { a: 'a', b: 1, c: [true], d: [1, 'foo'] }
+
+suite
+  .add('invalid payload', function() {
+    t.validate(payloadKO, T)
+  })
+  .add('valid payload (no errors)', function() {
+    t.validate(payloadOK, T)
+  })
+  .on('cycle', function(event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function() {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Either, Left, Right, isRight } from 'fp-ts/lib/Either'
+
 import { Predicate } from 'fp-ts/lib/function'
 
 declare global {
@@ -360,17 +361,18 @@ export const array = <RT extends Any>(
     (v): v is Array<TypeOf<RT>> => arrayType.is(v) && v.every(type.is),
     (s, c) =>
       arrayType.validate(s, c).chain(xs => {
-        const a: Array<TypeOf<RT>> = []
+        const len = xs.length
+        const a: Array<TypeOf<RT>> = Array(len)
         const errors: Errors = []
         let changed = false
-        for (let i = 0; i < xs.length; i++) {
+        for (let i = 0; i < len; i++) {
           const x = xs[i]
           const validation = type.validate(x, c.concat([getContextEntry(String(i), type)]))
           validation.fold(
             e => pushAll(errors, e),
             vx => {
               changed = changed || vx !== x
-              a.push(vx)
+              a[i] = vx
             }
           )
         }
@@ -737,7 +739,7 @@ export function tuple<RTS extends Array<Any>>(
     (v): v is any => arrayType.is(v) && v.length === len && types.every((type, i) => type.is(v[i])),
     (s, c) =>
       arrayType.validate(s, c).chain(as => {
-        const t: Array<any> = []
+        const t: Array<any> = Array(len)
         const errors: Errors = []
         let changed = false
         for (let i = 0; i < len; i++) {
@@ -748,7 +750,7 @@ export function tuple<RTS extends Array<Any>>(
             e => pushAll(errors, e),
             va => {
               changed = changed || va !== a
-              t.push(va)
+              t[i] = va
             }
           )
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export class AnyArrayType extends Type<any, Array<any>> {
   constructor() {
     super(
       'Array',
-      (v): v is Array<any> => Array.isArray(v),
+      Array.isArray as ((v: any) => v is Array<any>),
       (s, c) => (this.is(s) ? success(s) : failure(s, c)),
       identity
     )
@@ -496,7 +496,7 @@ export const partial = <P extends Props>(
   const partial = type(partials)
   return new PartialType(
     name,
-    (v): v is PartialOf<P> => partial.is(v),
+    partial.is as ((v: any) => v is PartialOf<P>),
     (s, c) => partial.validate(s, c) as any,
     useIdentity(props)
       ? identity
@@ -825,7 +825,7 @@ export const readonlyArray = <RT extends Any>(
   const arrayType = array(type)
   return new ReadonlyArrayType(
     name,
-    (v): v is ReadonlyArray<TypeOf<RT>> => arrayType.is(v),
+    arrayType.is as ((v: any) => v is ReadonlyArray<TypeOf<RT>>),
     (s, c) =>
       arrayType.validate(s, c).map(x => {
         if (process.env.NODE_ENV !== 'production') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Either, Left, Right, isRight } from 'fp-ts/lib/Either'
 
 import { Predicate } from 'fp-ts/lib/function'
+import { snoc } from 'fp-ts/lib/Array'
 
 declare global {
   interface Array<T> {
@@ -366,7 +367,7 @@ export const array = <RT extends Any>(
         const errors: Errors = []
         for (let i = 0; i < len; i++) {
           const x = xs[i]
-          const validation = type.validate(x, c.concat([getContextEntry(String(i), type)]))
+          const validation = type.validate(x, snoc(c)(getContextEntry(String(i), type)))
           validation.fold(
             e => pushAll(errors, e),
             vx => {
@@ -445,7 +446,7 @@ export const type = <P extends Props>(
         for (let k in props) {
           const ok = o[k]
           const type = props[k]
-          const validation = type.validate(ok, c.concat([getContextEntry(k, type)]))
+          const validation = type.validate(ok, snoc(c)(getContextEntry(k, type)))
           validation.fold(
             e => pushAll(errors, e),
             vok => {
@@ -554,8 +555,8 @@ export const dictionary = <D extends Any, C extends Any>(
         let changed = false
         for (let k in o) {
           const ok = o[k]
-          const domainValidation = domain.validate(k, c.concat([getContextEntry(k, domain)]))
-          const codomainValidation = codomain.validate(ok, c.concat([getContextEntry(k, codomain)]))
+          const domainValidation = domain.validate(k, snoc(c)(getContextEntry(k, domain)))
+          const codomainValidation = codomain.validate(ok, snoc(c)(getContextEntry(k, codomain)))
           domainValidation.fold(
             e => pushAll(errors, e),
             vk => {
@@ -615,7 +616,7 @@ export const union = <RTS extends Array<Any>>(
       const errors: Errors = []
       for (let i = 0; i < len; i++) {
         const type = types[i]
-        const validation = type.validate(s, c.concat([getContextEntry(String(i), type)]))
+        const validation = type.validate(s, snoc(c)(getContextEntry(String(i), type)))
         if (isRight(validation)) {
           return validation
         } else {
@@ -743,7 +744,7 @@ export function tuple<RTS extends Array<Any>>(
         for (let i = 0; i < len; i++) {
           const a = as[i]
           const type = types[i]
-          const validation = type.validate(a, c.concat([getContextEntry(String(i), type)]))
+          const validation = type.validate(a, snoc(c)(getContextEntry(String(i), type)))
           validation.fold(
             e => pushAll(errors, e),
             va => {
@@ -757,7 +758,7 @@ export function tuple<RTS extends Array<Any>>(
           )
         }
         if (as.length > len) {
-          errors.push(getValidationError(as[len], c.concat([getContextEntry(String(len), never)])))
+          errors.push(getValidationError(as[len], snoc(c)(getContextEntry(String(len), never))))
         }
         return errors.length ? failures(errors) : success(t as any)
       }),
@@ -876,7 +877,7 @@ export const strict = <P extends Props>(
           for (let i = 0; i < keys.length; i++) {
             const key = keys[i]
             if (!props.hasOwnProperty(key)) {
-              errors.push(getValidationError(o[key], c.concat([getContextEntry(key, never)])))
+              errors.push(getValidationError(o[key], snoc(c)(getContextEntry(key, never))))
             }
           }
           return errors.length ? failures(errors) : failure(o, c)

--- a/src/index.ts
+++ b/src/index.ts
@@ -503,7 +503,7 @@ export const partial = <P extends Props>(
   return new PartialType(
     name,
     partial.is as ((v: any) => v is PartialOf<P>),
-    (s, c) => partial.validate(s, c) as any,
+    partial.validate as any,
     useIdentity(props)
       ? identity
       : a => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,7 +365,7 @@ export const array = <RT extends Any>(
         let changed = false
         for (let i = 0; i < xs.length; i++) {
           const x = xs[i]
-          const validation = type.validate(x, c.concat(getContextEntry(String(i), type)))
+          const validation = type.validate(x, c.concat([getContextEntry(String(i), type)]))
           validation.fold(
             e => pushAll(errors, e),
             vx => {
@@ -441,7 +441,7 @@ export const type = <P extends Props>(
         for (let k in props) {
           const ok = o[k]
           const type = props[k]
-          const validation = type.validate(ok, c.concat(getContextEntry(k, type)))
+          const validation = type.validate(ok, c.concat([getContextEntry(k, type)]))
           validation.fold(
             e => pushAll(errors, e),
             vok => {
@@ -546,8 +546,8 @@ export const dictionary = <D extends Any, C extends Any>(
         let changed = false
         for (let k in o) {
           const ok = o[k]
-          const domainValidation = domain.validate(k, c.concat(getContextEntry(k, domain)))
-          const codomainValidation = codomain.validate(ok, c.concat(getContextEntry(k, codomain)))
+          const domainValidation = domain.validate(k, c.concat([getContextEntry(k, domain)]))
+          const codomainValidation = codomain.validate(ok, c.concat([getContextEntry(k, codomain)]))
           domainValidation.fold(
             e => pushAll(errors, e),
             vk => {
@@ -607,7 +607,7 @@ export const union = <RTS extends Array<Any>>(
       const errors: Errors = []
       for (let i = 0; i < len; i++) {
         const type = types[i]
-        const validation = type.validate(s, c.concat(getContextEntry(String(i), type)))
+        const validation = type.validate(s, c.concat([getContextEntry(String(i), type)]))
         if (isRight(validation)) {
           return validation
         } else {
@@ -743,7 +743,7 @@ export function tuple<RTS extends Array<Any>>(
         for (let i = 0; i < len; i++) {
           const a = as[i]
           const type = types[i]
-          const validation = type.validate(a, c.concat(getContextEntry(String(i), type)))
+          const validation = type.validate(a, c.concat([getContextEntry(String(i), type)]))
           validation.fold(
             e => pushAll(errors, e),
             va => {
@@ -753,7 +753,7 @@ export function tuple<RTS extends Array<Any>>(
           )
         }
         if (as.length > len) {
-          errors.push(getValidationError(as[len], c.concat(getContextEntry(String(len), never))))
+          errors.push(getValidationError(as[len], c.concat([getContextEntry(String(len), never)])))
         }
         return errors.length ? failures(errors) : success((changed ? t : as) as any)
       }),
@@ -872,7 +872,7 @@ export const strict = <P extends Props>(
           for (let i = 0; i < keys.length; i++) {
             const key = keys[i]
             if (!props.hasOwnProperty(key)) {
-              errors.push(getValidationError(o[key], c.concat(getContextEntry(key, never))))
+              errors.push(getValidationError(o[key], c.concat([getContextEntry(key, never)])))
             }
           }
           return errors.length ? failures(errors) : failure(o, c)

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -1,9 +1,20 @@
-import * as assert from 'assert'
 import * as Benchmark from 'benchmark'
-import { Context, getDefaultContext, getContextEntry, string, number } from '../src/index'
+import * as assert from 'assert'
+
+import { Context, getContextEntry, getDefaultContext, number, string } from '../src/index'
 
 const suite = new Benchmark.Suite()
 const c: Context = getDefaultContext(string)
+
+const appendNext = (arr: any[], e: any) => {
+  const len = arr.length
+  const res = Array(len + 1)
+  for (let i = 0; i < len; i++) {
+    res[i] = arr[i]
+  }
+  res[len] = e
+  return res
+}
 
 describe('perf', () => {
   ;(it('concat([a]) should be faster than concat(a)', done => {
@@ -13,6 +24,9 @@ describe('perf', () => {
       })
       .add('concat([e])', function() {
         c.concat([getContextEntry('key', number)])
+      })
+      .add('manual appendNext function', function() {
+        appendNext(c, getContextEntry('key', number))
       })
       .on('cycle', function(event: any) {
         console.log(String(event.target))

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert'
+import * as Benchmark from 'benchmark'
+import { Context, getDefaultContext, getContextEntry, string, number } from '../src/index'
+
+const suite = new Benchmark.Suite()
+const c: Context = getDefaultContext(string)
+
+describe('perf', () => {
+  ;(it('concat([a]) should be faster than concat(a)', done => {
+    suite
+      .add('concat(e)', function() {
+        c.concat(getContextEntry('key', number))
+      })
+      .add('concat([e])', function() {
+        c.concat([getContextEntry('key', number)])
+      })
+      .on('cycle', function(event: any) {
+        console.log(String(event.target))
+      })
+      .on('complete', function(this: any) {
+        assert.deepEqual(this.filter('fastest').map('name'), ['concat([e])'])
+        done()
+      })
+      .run({ async: true })
+  }) as any).timeout(20000)
+})

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -1,7 +1,14 @@
+/*
 import * as Benchmark from 'benchmark'
 import * as assert from 'assert'
 
-import { Context, getContextEntry, getDefaultContext, number, string } from '../src/index'
+import {
+  Context,
+  getContextEntry,
+  getDefaultContext,
+  number,
+  string
+} from '../src/index'
 
 const suite = new Benchmark.Suite()
 const c: Context = getDefaultContext(string)
@@ -26,7 +33,7 @@ describe('perf', () => {
         c.concat([getContextEntry('key', number)])
       })
       .add('manual appendNext function', function() {
-        appendNext(c, getContextEntry('key', number))
+        snoc(c, getContextEntry('key', number))
       })
       .on('cycle', function(event: any) {
         console.log(String(event.target))
@@ -38,3 +45,4 @@ describe('perf', () => {
       .run({ async: true })
   }) as any).timeout(20000)
 })
+*/

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -13,7 +13,6 @@
     "allowJs": false,
     "target": "es5",
     "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "lib": ["es6", "dom"]
+    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
Using `./perf/index.js`

---

`concat(element)` (current implementation)

invalid payload x 200,425 ops/sec ±0.74% (89 runs sampled)
valid payload (no errors) x 181,576 ops/sec ±1.00% (87 runs sampled)

`concat([element])`

invalid payload x 258,902 ops/sec ±0.61% (89 runs sampled)
valid payload (no errors) x 227,362 ops/sec ±1.54% (86 runs sampled)
