### PR TITLE
make recursion safer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,7 +353,7 @@ export class RecursiveType<RT extends Any, A> extends Type<mixed, A> {
   }
 }
 
-export const recursion = <A, RT extends Any = Any>(
+export const recursion = <A, RT extends Type<mixed, A> = Type<mixed, A>>(
   name: string,
   definition: (self: RT) => RT
 ): RecursiveType<RT, A> => {

--- a/test/recursion.ts
+++ b/test/recursion.ts
@@ -4,7 +4,11 @@ import { assertSuccess, assertFailure, assertStrictEqual, DateFromNumber } from 
 
 describe('recursion', () => {
   it('should succeed validating a valid value', () => {
-    const T = t.recursion('T', self =>
+    type T = {
+      a: number
+      b: T | undefined | null
+    }
+    const T = t.recursion<T>('T', self =>
       t.interface({
         a: t.number,
         b: t.union([self, t.undefined, t.null])
@@ -15,7 +19,11 @@ describe('recursion', () => {
   })
 
   it('should return the same reference if validation succeeded', () => {
-    const T = t.recursion('T', self =>
+    type T = {
+      a: number
+      b: T | undefined | null
+    }
+    const T = t.recursion<T>('T', self =>
       t.interface({
         a: t.number,
         b: t.union([self, t.undefined, t.null])
@@ -26,7 +34,11 @@ describe('recursion', () => {
   })
 
   it('should fail validating an invalid value', () => {
-    const T = t.recursion('T', self =>
+    type T = {
+      a: number
+      b: T | undefined | null
+    }
+    const T = t.recursion<T>('T', self =>
       t.interface({
         a: t.number,
         b: t.union([self, t.undefined, t.null])

--- a/typings-checker/index.ts
+++ b/typings-checker/index.ts
@@ -2,6 +2,28 @@ import * as t from '../src'
 import { TypeOf } from '../src'
 
 //
+// recursion
+//
+type RecT1 = {
+  type: 'a'
+  items: Array<RecT1>
+}
+
+const Rec1 = t.recursion<RecT1>('T', Self =>
+  t.interface({
+    type: t.literal('a'),
+    items: t.array(Self)
+  })
+)
+// $ExpectError Type 'InterfaceOf<{ type: LiteralType<"a">; items: ArrayType<Type<mixed, string>, string[]>; }>' is not assignable to type 'string'
+const Rec2 = t.recursion<string>('T', Self =>
+  t.interface({
+    type: t.literal('a'),
+    items: t.array(Self)
+  })
+)
+
+//
 // literal
 //
 
@@ -167,3 +189,114 @@ type TO1 = TypeOf<typeof O1>
 const x34: TO1 = { name: 'Giulio' }
 // $ExpectError Type '"foo"' is not assignable to type 'object'
 const x35: TO1 = 'foo'
+
+type GenerableProps = { [key: string]: Generable }
+type GenerableInterface = t.InterfaceType<GenerableProps, any>
+type GenerableStrict = t.StrictType<GenerableProps, any>
+type GenerablePartials = t.PartialType<GenerableProps, any>
+interface GenerableDictionary extends t.DictionaryType<Generable, Generable, any> {}
+interface GenerableRefinement extends t.RefinementType<Generable, any, any> {}
+interface GenerableArray extends t.ArrayType<Generable, any> {}
+interface GenerableUnion extends t.UnionType<Array<Generable>, any> {}
+interface GenerableIntersection extends t.IntersectionType<Array<Generable>, any> {}
+interface GenerableTuple extends t.TupleType<Array<Generable>, any> {}
+interface GenerableReadonly extends t.ReadonlyType<Generable, any> {}
+interface GenerableReadonlyArray extends t.ReadonlyArrayType<Generable, any> {}
+interface GenerableRecursive extends t.RecursiveType<Generable, any> {}
+type Generable =
+  | t.StringType
+  | t.NumberType
+  | t.BooleanType
+  | GenerableInterface
+  | GenerableRefinement
+  | GenerableArray
+  | GenerableStrict
+  | GenerablePartials
+  | GenerableDictionary
+  | GenerableUnion
+  | GenerableIntersection
+  | GenerableTuple
+  | GenerableReadonly
+  | GenerableReadonlyArray
+  | t.LiteralType<any>
+  | t.KeyofType<any>
+  | GenerableRecursive
+  | t.UndefinedType
+
+function f(generable: Generable): string {
+  switch (generable._tag) {
+    case 'InterfaceType':
+      return Object.keys(generable.props)
+        .map(k => f(generable.props[k]))
+        .join('/')
+    case 'StringType':
+      return 'StringType'
+    case 'NumberType':
+      return 'StringType'
+    case 'BooleanType':
+      return 'BooleanType'
+    case 'RefinementType':
+      return f(generable.type)
+    case 'ArrayType':
+      return 'ArrayType'
+    case 'StrictType':
+      return 'StrictType'
+    case 'PartialType':
+      return 'PartialType'
+    case 'DictionaryType':
+      return 'DictionaryType'
+    case 'UnionType':
+      return 'UnionType'
+    case 'IntersectionType':
+      return 'IntersectionType'
+    case 'TupleType':
+      return generable.types.map(type => f(type)).join('/')
+    case 'ReadonlyType':
+      return 'ReadonlyType'
+    case 'ReadonlyArrayType':
+      return 'ReadonlyArrayType'
+    case 'LiteralType':
+      return 'LiteralType'
+    case 'KeyofType':
+      return 'KeyofType'
+    case 'RecursiveType':
+      return f(generable.type)
+    case 'UndefinedType':
+      return 'UndefinedType'
+  }
+}
+
+const schema = t.interface({
+  a: t.string,
+  b: t.union([
+    t.partial({
+      c: t.string,
+      d: t.literal('eee')
+    }),
+    t.boolean
+  ]),
+  e: t.intersection([
+    t.interface({
+      f: t.array(t.string)
+    }),
+    t.interface({
+      g: t.union([t.literal('toto'), t.literal('tata')])
+    })
+  ])
+})
+
+f(schema) // OK!
+
+type Rec = {
+  a: number
+  b: Rec | undefined
+}
+
+const Rec = t.recursion<Rec, GenerableInterface>('T', Self =>
+  t.interface({
+    a: t.number,
+    b: t.union([Self, t.undefined])
+  })
+)
+
+f(Rec) // OK!


### PR DESCRIPTION
Currently the following doesn't raise any error

```ts
// string???
const T = t.recursion<string>('T', Self =>
  t.interface({
    type: t.literal('a'),
    items: t.array(Self)
  })
)
```