### PR TITLE
 add validate overload with implicit context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
   readonly '_A': A
   // prettier-ignore
   readonly '_S': S
+  readonly maybe: (value: A) => Validation<A>
   constructor(
     /** a unique name for this runtime type */
     readonly name: string,
@@ -58,7 +59,9 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
     readonly validate: Validate<S, A>,
     /** converts a value of type A to a value of type S */
     readonly serialize: Serialize<S, A>
-  ) {}
+  ) {
+    this.maybe = (value: any) => validate(value, [{ key: '', type: this }])
+  }
   pipe<B>(ab: Type<A, B>, name?: string): Type<S, B> {
     return new Type(
       name || `pipe(${this.name}, ${ab.name})`,

--- a/test/interface.ts
+++ b/test/interface.ts
@@ -9,14 +9,14 @@ describe('interface', () => {
     assertSuccess(t.validate({ a: 's' }, T))
   })
 
-  it('should succeed validating a valid value with maybe', () => {
+  it('should succeed validating a valid value with implicit context', () => {
     const T = t.interface({ a: t.string })
-    assertSuccess(T.maybe({ a: 's' }))
+    assertSuccess(T.validate({ a: 's' }))
   })
 
-  it('should succeed validating with maybe without binding', () => {
+  it('should succeed validating with implicit context without binding', () => {
     const T = t.interface({ a: t.string })
-    const validation = [{ a: 's' }].map(T.maybe)[0] // no need for T.maybe.bind(T)
+    const validation = [{ a: 's' }].map(T.validate)[0] // no need for T.validate.bind(T)
     assertSuccess(validation)
   })
 
@@ -48,12 +48,12 @@ describe('interface', () => {
     assertFailure(t.validate({ a: 1 }, T), ['Invalid value 1 supplied to : { a: string }/a: string'])
   })
 
-  it('should fail validating an invalid value with maybe', () => {
+  it('should fail validating an invalid value with implicit context', () => {
     const T = t.interface({ a: t.string })
-    // "as any" is required here because T.maybe validates the input type
-    assertFailure(T.maybe(1 as any), ['Invalid value 1 supplied to : { a: string }'])
-    assertFailure(T.maybe({} as any), ['Invalid value undefined supplied to : { a: string }/a: string'])
-    assertFailure(T.maybe({ a: 1 } as any), ['Invalid value 1 supplied to : { a: string }/a: string'])
+    // "as any" is required here because T.validate with one argument validates the input type
+    assertFailure(T.validate(1 as any), ['Invalid value 1 supplied to : { a: string }'])
+    assertFailure(T.validate({} as any), ['Invalid value undefined supplied to : { a: string }/a: string'])
+    assertFailure(T.validate({ a: 1 } as any), ['Invalid value 1 supplied to : { a: string }/a: string'])
   })
 
   it('should support the alias `type`', () => {

--- a/test/interface.ts
+++ b/test/interface.ts
@@ -9,6 +9,17 @@ describe('interface', () => {
     assertSuccess(t.validate({ a: 's' }, T))
   })
 
+  it('should succeed validating a valid value with maybe', () => {
+    const T = t.interface({ a: t.string })
+    assertSuccess(T.maybe({ a: 's' }))
+  })
+
+  it('should succeed validating with maybe without binding', () => {
+    const T = t.interface({ a: t.string })
+    const validation = [{ a: 's' }].map(T.maybe)[0] // no need for T.maybe.bind(T)
+    assertSuccess(validation)
+  })
+
   it('should keep unknown properties', () => {
     const T = t.interface({ a: t.string })
     const validation = t.validate({ a: 's', b: 1 }, T)
@@ -35,6 +46,14 @@ describe('interface', () => {
     assertFailure(t.validate(1, T), ['Invalid value 1 supplied to : { a: string }'])
     assertFailure(t.validate({}, T), ['Invalid value undefined supplied to : { a: string }/a: string'])
     assertFailure(t.validate({ a: 1 }, T), ['Invalid value 1 supplied to : { a: string }/a: string'])
+  })
+
+  it('should fail validating an invalid value with maybe', () => {
+    const T = t.interface({ a: t.string })
+    // "as any" is required here because T.maybe validates the input type
+    assertFailure(T.maybe(1 as any), ['Invalid value 1 supplied to : { a: string }'])
+    assertFailure(T.maybe({} as any), ['Invalid value undefined supplied to : { a: string }/a: string'])
+    assertFailure(T.maybe({ a: 1 } as any), ['Invalid value 1 supplied to : { a: string }/a: string'])
   })
 
   it('should support the alias `type`', () => {


### PR DESCRIPTION
this adds an overload to `validate` which takes a single argument - a POJO that is expected to be the target type. It doesn't take a context array, and it does compile-time validation of the input type.

This is useful if you want to build up an interface instance out of variables from external sources, and you want:
1. the IDE to be able to give you type hints of what properties *should* be on the object (see VSCode example below)
2. to be able to use the more natural style of `Person.validate({ name: "Bob" })` syntax over `t.validate({ name: "Bob" }, Person)`
3. to not have to pass in a context array explicitly like `Person.validate({ name: "Bob" }), [{ key: "", type: Person }])` or more likely (but worse), no context at all like `Person.validate({ name: "Bob" }, [])`
4. to not have to `import * as t from "io-ts"` when you just want to use types defined elsewhere, but don't want to import io-ts directly. You can just `import { Person } from "./foo/bar"`

Usage example:
```javascript
import * as t from "io-ts"

const Person = t.interface({
  name: t.string,
  age: t.number,
})

const alice = Person.validate({ name: "alice", age: "thirty" }) // compile time error, age should be of type "number"
const bob = Person.validate({ name: "bob", age: 30 }) // equivalent of calling t.validate({ name: "bob", age: 30 }, Person)
```

VSCode type hints:
![image](https://user-images.githubusercontent.com/15040698/35551378-d19514d4-055c-11e8-89ac-e56e9a82574d.png)

Curious to see what you think @gcanti - for the application I'm trying to use this in, it'd make io-ts a no-brainer as it'll give a very clean way to get both runtime and compile time type-checking.