### PR TITLE
UPDATED - validate overload without target type parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
     /** converts a value of type A to a value of type S */
     readonly serialize: Serialize<S, A>
   ) {
-    this.validate = (s: any, c?: any[]) => _validate(s, c || [{ key: '', type: this }])
+    this.validate = (s, c) => _validate(s, c || [{ key: '', type: this }])
   }
   pipe<B>(ab: Type<A, B>, name?: string): Type<S, B> {
     return new Type(

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,12 +49,7 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
   readonly '_A': A
   // prettier-ignore
   readonly '_S': S
-  readonly validate: {
-    /** succeeds if a value of type A can be decoded at runtime */
-    (s: S): Validation<A>
-    /** succeeds if a value of type S can be decoded to a value of type A */
-    (s: S, context: Context): Validation<A>
-  }
+  readonly validate: (s: S, context?: Context) => Validation<A>
   constructor(
     /** a unique name for this runtime type */
     readonly name: string,
@@ -65,7 +60,7 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
     /** converts a value of type A to a value of type S */
     readonly serialize: Serialize<S, A>
   ) {
-    this.validate = (s: any, c: any[] | null = null) => _validate(s, c || [{ key: '', type: this }])
+    this.validate = (s: any, c?: any[]) => _validate(s, c || [{ key: '', type: this }])
   }
   pipe<B>(ab: Type<A, B>, name?: string): Type<S, B> {
     return new Type(

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
   readonly '_A': A
   // prettier-ignore
   readonly '_S': S
+  readonly maybe: (value: A) => Validation<A>
   constructor(
     /** a unique name for this runtime type */
     readonly name: string,
@@ -58,7 +59,9 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
     readonly validate: Validate<S, A>,
     /** converts a value of type A to a value of type S */
     readonly serialize: Serialize<S, A>
-  ) {}
+  ) {
+    this.maybe = (value: any) => validate(value, [{ key: '', type: this }])
+  }
   pipe<B>(ab: Type<A, B>, name?: string): Type<S, B> {
     return new Type(
       name || `pipe(${this.name}, ${ab.name})`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
   readonly '_S': S
   readonly validate: {
     /** succeeds if a value of type A can be decoded at runtime */
-    (value: A): Validation<A>
+    (s: S): Validation<A>
     /** succeeds if a value of type S can be decoded to a value of type A */
     (s: S, context: Context): Validation<A>
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,10 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
   readonly '_A': A
   // prettier-ignore
   readonly '_S': S
-  readonly validate: (s: S, context?: Context) => Validation<A>
+  readonly validate: {
+    (s: S): Validation<A>
+    (s: S, context?: Context): Validation<A>
+  }
   constructor(
     /** a unique name for this runtime type */
     readonly name: string,
@@ -60,7 +63,7 @@ export class Type<S, A> implements Decoder<S, A>, Encoder<S, A> {
     /** converts a value of type A to a value of type S */
     readonly serialize: Serialize<S, A>
   ) {
-    this.validate = (s, c) => _validate(s, c || [{ key: '', type: this }])
+    this.validate = (s: S, c?: Context) => _validate(s, c || [{ key: '', type: this }])
   }
   pipe<B>(ab: Type<A, B>, name?: string): Type<S, B> {
     return new Type(

--- a/test/interface.ts
+++ b/test/interface.ts
@@ -9,14 +9,14 @@ describe('interface', () => {
     assertSuccess(t.validate({ a: 's' }, T))
   })
 
-  it('should succeed validating a valid value with maybe', () => {
+  it('should succeed validating a valid value with implicit context', () => {
     const T = t.interface({ a: t.string })
-    assertSuccess(T.maybe({ a: 's' }))
+    assertSuccess(T.validate({ a: 's' }))
   })
 
-  it('should succeed validating with maybe without binding', () => {
+  it('should succeed validating with implicit context without binding', () => {
     const T = t.interface({ a: t.string })
-    const validation = [{ a: 's' }].map(T.maybe)[0] // no need for T.maybe.bind(T)
+    const validation = [{ a: 's' }].map(T.validate)[0] // no need for T.validate.bind(T)
     assertSuccess(validation)
   })
 
@@ -48,12 +48,12 @@ describe('interface', () => {
     assertFailure(t.validate({ a: 1 }, T), ['Invalid value 1 supplied to : { a: string }/a: string'])
   })
 
-  it('should fail validating an invalid value with maybe', () => {
+  it('should fail validating an invalid value with implicit context', () => {
     const T = t.interface({ a: t.string })
-    // "as any" is required here because T.maybe validates the input type
-    assertFailure(T.maybe(1 as any), ['Invalid value 1 supplied to : { a: string }'])
-    assertFailure(T.maybe({} as any), ['Invalid value undefined supplied to : { a: string }/a: string'])
-    assertFailure(T.maybe({ a: 1 } as any), ['Invalid value 1 supplied to : { a: string }/a: string'])
+    // "as any" is required here because T.validate with one argument validates the input type
+    assertFailure(T.validate(1 as any), ['Invalid value 1 supplied to : { a: string }'])
+    assertFailure(T.validate({} as any), ['Invalid value undefined supplied to : { a: string }/a: string'])
+    assertFailure(T.validate({ a: 1 } as any), ['Invalid value 1 supplied to : { a: string }/a: string'])
   })
 
   it('should support the alias `type`', () => {

--- a/test/interface.ts
+++ b/test/interface.ts
@@ -50,7 +50,6 @@ describe('interface', () => {
 
   it('should fail validating an invalid value with implicit context', () => {
     const T = t.interface({ a: t.string })
-    // "as any" is required here because T.validate with one argument validates the input type
     assertFailure(T.validate(1), ['Invalid value 1 supplied to : { a: string }'])
     assertFailure(T.validate({}), ['Invalid value undefined supplied to : { a: string }/a: string'])
     assertFailure(T.validate({ a: 1 }), ['Invalid value 1 supplied to : { a: string }/a: string'])

--- a/test/interface.ts
+++ b/test/interface.ts
@@ -51,9 +51,9 @@ describe('interface', () => {
   it('should fail validating an invalid value with implicit context', () => {
     const T = t.interface({ a: t.string })
     // "as any" is required here because T.validate with one argument validates the input type
-    assertFailure(T.validate(1 as any), ['Invalid value 1 supplied to : { a: string }'])
-    assertFailure(T.validate({} as any), ['Invalid value undefined supplied to : { a: string }/a: string'])
-    assertFailure(T.validate({ a: 1 } as any), ['Invalid value 1 supplied to : { a: string }/a: string'])
+    assertFailure(T.validate(1), ['Invalid value 1 supplied to : { a: string }'])
+    assertFailure(T.validate({}), ['Invalid value undefined supplied to : { a: string }/a: string'])
+    assertFailure(T.validate({ a: 1 }), ['Invalid value 1 supplied to : { a: string }/a: string'])
   })
 
   it('should support the alias `type`', () => {

--- a/test/interface.ts
+++ b/test/interface.ts
@@ -9,6 +9,17 @@ describe('interface', () => {
     assertSuccess(t.validate({ a: 's' }, T))
   })
 
+  it('should succeed validating a valid value with maybe', () => {
+    const T = t.interface({ a: t.string })
+    assertSuccess(T.maybe({ a: 's' }))
+  })
+
+  it('should succeed validating with maybe without binding', () => {
+    const T = t.interface({ a: t.string })
+    const validation = [{ a: 's' }].map(T.maybe)[0] // no need for T.maybe.bind(T)
+    assertSuccess(validation)
+  })
+
   it('should keep unknown properties', () => {
     const T = t.interface({ a: t.string })
     const validation = t.validate({ a: 's', b: 1 }, T)
@@ -35,6 +46,14 @@ describe('interface', () => {
     assertFailure(t.validate(1, T), ['Invalid value 1 supplied to : { a: string }'])
     assertFailure(t.validate({}, T), ['Invalid value undefined supplied to : { a: string }/a: string'])
     assertFailure(t.validate({ a: 1 }, T), ['Invalid value 1 supplied to : { a: string }/a: string'])
+  })
+
+  it('should fail validating an invalid value with maybe', () => {
+    const T = t.interface({ a: t.string })
+    // "as any" is required here because T.maybe validates the input type
+    assertFailure(T.maybe(1 as any), ['Invalid value 1 supplied to : { a: string }'])
+    assertFailure(T.maybe({} as any), ['Invalid value undefined supplied to : { a: string }/a: string'])
+    assertFailure(T.maybe({ a: 1 } as any), ['Invalid value 1 supplied to : { a: string }/a: string'])
   })
 
   it('should support the alias `type`', () => {


### PR DESCRIPTION
@gcanti feedback taken on https://github.com/gcanti/io-ts/pull/118 - I have removed the `(value: A): Validation<A>` part, so now all this is is an overload for `MyType.validate(...)` which will pass in a sensible default context for you in the second parameter.

On reflection, it's cleaner this way - just a simple change to make a single parameter optional. Everything otherwise stays the same. Would you be happy to take this in? There's a usage example in the tests added.