### PR TITLE
Flatten `chain`s optimization

### DIFF
--- a/test/Type.ts
+++ b/test/Type.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert'
+import * as t from '../src/index'
+import { assertFailure } from './helpers'
+import { right } from 'fp-ts/lib/Either'
+
+describe('Type', () => {
+  it('pipe', () => {
+    const AOI = t.string
+    const BAA = new t.Type<number, string, string>(
+      'BAA',
+      t.number.is,
+      (s, c) => {
+        const n = parseFloat(s)
+        return isNaN(n) ? t.failure(s, c) : t.success(n)
+      },
+      n => String(n)
+    )
+    const T = AOI.pipe(BAA, 'T')
+    assert.deepEqual(T.decode('1'), right(1))
+    assertFailure(T.decode('a'), ['Invalid value "a" supplied to : T'])
+  })
+})


### PR DESCRIPTION
Baseline (best result from https://github.com/gcanti/io-ts/pull/134)

```
space-object (good) x 514,274 ops/sec ±0.45% (88 runs sampled)
space-object (bad) x 479,642 ops/sec ±0.54% (86 runs sampled)
```

After this change

```
space-object (good) x 592,606 ops/sec ±0.52% (87 runs sampled)
space-object (bad) x 532,306 ops/sec ±1.18% (81 runs sampled)
```