### PR TITLE
Internal: remove for in loops

### DIFF
--- a/perf/dictionary.js
+++ b/perf/dictionary.js
@@ -1,0 +1,44 @@
+var Benchmark = require('benchmark')
+var t = require('../lib/index')
+
+const suite = new Benchmark.Suite()
+
+const T = t.dictionary(t.string, t.number)
+
+const valid = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 4,
+  e: 5,
+  f: 6,
+  g: 7,
+  h: 8,
+  i: 9
+}
+const invalid = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 4,
+  e: 5,
+  f: 6,
+  g: 7,
+  h: 8,
+  i: 'a'
+}
+
+suite
+  .add('t.dictionary (valid)', function() {
+    T.decode(valid)
+  })
+  .add('t.dictionary (invalid)', function() {
+    T.decode(invalid)
+  })
+  .on('cycle', function(event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function() {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })

--- a/perf/partial.js
+++ b/perf/partial.js
@@ -1,0 +1,39 @@
+var Benchmark = require('benchmark')
+var t = require('../lib/index')
+
+const suite = new Benchmark.Suite()
+
+const T = t.partial({
+  a: t.number,
+  b: t.number,
+  c: t.number,
+  d: t.number
+})
+
+const valid = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 4
+}
+const invalid = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 'a'
+}
+
+suite
+  .add('t.partial (valid)', function() {
+    T.decode(valid)
+  })
+  .add('t.partial (invalid)', function() {
+    T.decode(invalid)
+  })
+  .on('cycle', function(event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function() {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })


### PR DESCRIPTION
Baseline

```
space-object (good) x 575,397 ops/sec ±1.73% (88 runs sampled)
space-object (bad) x 538,299 ops/sec ±0.91% (92 runs sampled)
```

after this change

```
space-object (good) x 666,376 ops/sec ±0.40% (88 runs sampled)
space-object (bad) x 587,146 ops/sec ±0.90% (85 runs sampled)
```

EDIT: also

**dictionary**

Baseline

```
t.dictionary (valid) x 1,302,817 ops/sec ±0.58% (85 runs sampled)
t.dictionary (invalid) x 1,029,034 ops/sec ±0.48% (89 runs sampled)
```

after this change

```
t.dictionary (valid) x 1,344,179 ops/sec ±0.63% (84 runs sampled)
t.dictionary (invalid) x 1,246,889 ops/sec ±0.44% (88 runs sampled)
```

**partial**

Baseline

```
t.partial (valid) x 2,552,128 ops/sec ±0.67% (88 runs sampled)
t.partial (invalid) x 1,627,970 ops/sec ±0.36% (90 runs sampled)
```

after this change

```
t.partial (valid) x 2,924,498 ops/sec ±0.56% (87 runs sampled)
t.partial (invalid) x 1,776,725 ops/sec ±0.34% (89 runs sampled)
```