### PR TITLE
Internal: add push-slice-pop optimization

### DIFF
--- a/test/strictInterfaceWithOptionals.ts
+++ b/test/strictInterfaceWithOptionals.ts
@@ -40,6 +40,10 @@ describe('strictInterfaceWithOptionals', () => {
   it('should fail validating an invalid value', () => {
     const T = strictInterfaceWithOptionals({ foo: t.string }, { bar: t.string }, 'T')
     assertFailure(T.decode({ foo: 'foo', a: 1 }), ['Invalid value 1 supplied to : T/a: never'])
+    assertFailure(T.decode({ foo: 'foo', a: 1, b: 2 }), [
+      'Invalid value 1 supplied to : T/a: never',
+      'Invalid value 2 supplied to : T/b: never'
+    ])
     assertFailure(T.decode({ foo: 'foo', bar: 1 }), [
       'Invalid value 1 supplied to : T/bar: (string | undefined)/0: string',
       'Invalid value 1 supplied to : T/bar: (string | undefined)/1: undefined'


### PR DESCRIPTION
@sledorze the gist is

- `context` is _mutable_ (I feel a bit dirty for this) and I push / pop `ContextEntry`s while traversing the tree
- if an error is encountered then I take a snapshot of the current `context` by calling `context.slice()` in the `failure` API

Analysis:

In the best case (which we should optimize for) only one array is created and no snapshots at all.
In the worst case (all leafs are invalid) I guess it does less work as well

Benchmarks:

Baseline (from last PR)

```
space-object (good) x 666,376 ops/sec ±0.40% (88 runs sampled)
space-object (bad) x 587,146 ops/sec ±0.90% (85 runs sampled)
```

after this change

```
space-object (good) x 1,021,748 ops/sec ±0.39% (89 runs sampled)
space-object (bad) x 748,862 ops/sec ±0.64% (89 runs sampled)
```

The main point is: this change looks backward compatible if the `failure` API is consistently used, or am I wrong?