### PR TITLE
Bug Fix: `taggedUnion` fails to decode when tag values are not string…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 1.0.6
+
+* **Bug Fix**
+  * `taggedUnion` fails to decode when tag values are not string literals, fix #161 (@gcanti)
+
 # 1.0.5
 
 * **Bug Fix**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "1.1.0",
+  "version": "1.0.6",
   "description": "TypeScript compatible runtime type system for IO validation",
   "files": ["lib"],
   "main": "lib/index.js",

--- a/perf/taggedUnion.js
+++ b/perf/taggedUnion.js
@@ -1,0 +1,60 @@
+var Benchmark = require('benchmark')
+var t = require('../lib/index')
+
+const suite = new Benchmark.Suite()
+
+const TUA = t.type(
+  {
+    type: t.literal('a'),
+    foo: t.string
+  },
+  'TUA'
+)
+
+const TUB = t.intersection(
+  [
+    t.type({
+      type: t.literal('b')
+    }),
+    t.type({
+      bar: t.number
+    })
+  ],
+  'TUB'
+)
+
+const DateFromNumber = new t.Type(
+  'DateFromNumber',
+  v => v instanceof Date,
+  (s, c) =>
+    t.number.validate(s, c).chain(n => {
+      const d = new Date(n)
+      return isNaN(d.getTime()) ? t.failure(n, c) : t.success(d)
+    }),
+  a => a.getTime()
+)
+
+const TUC = t.type(
+  {
+    type: t.literal('c'),
+    baz: DateFromNumber
+  },
+  'TUC'
+)
+
+const T = t.taggedUnion('type', [TUA, TUB, TUC])
+
+suite
+  .add('taggedUnion (valid)', function() {
+    T.decode({ type: 'a', foo: 'foo' })
+  })
+  .add('taggedUnion (invalid)', function() {
+    T.decode({ type: 'D' })
+  })
+  .on('cycle', function(event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function() {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })

--- a/test/taggedUnion.ts
+++ b/test/taggedUnion.ts
@@ -46,9 +46,7 @@ describe('taggedUnion', () => {
 
   it('should fail validating an invalid value', () => {
     assertFailure(T.decode(true), ['Invalid value true supplied to : (TUA | TUB | TUC)'])
-    assertFailure(T.decode({ type: 'D' }), [
-      'Invalid value "D" supplied to : (TUA | TUB | TUC)/type: (keyof ["a","b","c"])'
-    ])
+    assertFailure(T.decode({ type: 'D' }), ['Invalid value "D" supplied to : (TUA | TUB | TUC)/type: "a" | "b" | "c"'])
     assertFailure(T.decode({ type: 'a' }), [
       'Invalid value undefined supplied to : (TUA | TUB | TUC)/0: TUA/foo: string'
     ])
@@ -77,5 +75,112 @@ describe('taggedUnion', () => {
     assert.strictEqual(T.is({ type: 'c', baz: new Date(0) }), true)
     assert.strictEqual(T.is(true), false)
     assert.strictEqual(T.is({ type: 'a' }), false)
+  })
+
+  it('should work when tag values are numbers', () => {
+    const A = t.type(
+      {
+        type: t.literal(1),
+        foo: t.string
+      },
+      'A'
+    )
+
+    const B = t.type(
+      {
+        type: t.literal(2),
+        bar: t.number
+      },
+      'B'
+    )
+
+    const C = t.type(
+      {
+        type: t.literal(3),
+        baz: DateFromNumber
+      },
+      'C'
+    )
+
+    const U = t.taggedUnion('type', [A, B, C], 'U')
+
+    assert.strictEqual(U.is({ type: 1, foo: 'foo' }), true)
+    assert.strictEqual(U.is({ type: 1, foo: 0 }), false)
+    assert.strictEqual(U.is({ type: 2, bar: 0 }), true)
+    assert.strictEqual(U.is({ type: 2, bar: 'bar' }), false)
+    assert.strictEqual(U.is({ type: 4 }), false)
+    assert.strictEqual(U.is({ type: '1', foo: 'foo' }), false)
+
+    assertSuccess(U.decode({ type: 1, foo: 'foo' }))
+    assertFailure(U.decode({ type: 1, foo: 0 }), ['Invalid value 0 supplied to : U/0: A/foo: string'])
+    assertSuccess(U.decode({ type: 2, bar: 0 }))
+    assertFailure(U.decode({ type: 2, bar: 'bar' }), ['Invalid value "bar" supplied to : U/1: B/bar: number'])
+    assertFailure(U.decode({ type: 4 }), ['Invalid value 4 supplied to : U/type: 1 | 2 | 3'])
+
+    assert.deepEqual(U.encode({ type: 3, baz: new Date(0) }), { type: 3, baz: 0 })
+  })
+
+  it('should work when tag values are booleans', () => {
+    const A = t.type(
+      {
+        type: t.literal(true),
+        foo: t.string
+      },
+      'A'
+    )
+
+    const B = t.type(
+      {
+        type: t.literal(false),
+        bar: t.number
+      },
+      'B'
+    )
+
+    const U = t.taggedUnion('type', [A, B], 'U')
+
+    assert.strictEqual(U.is({ type: true, foo: 'foo' }), true)
+    assert.strictEqual(U.is({ type: true, foo: 0 }), false)
+    assert.strictEqual(U.is({ type: false, bar: 0 }), true)
+    assert.strictEqual(U.is({ type: false, bar: 'bar' }), false)
+    assert.strictEqual(U.is({ type: 3 }), false)
+
+    assertSuccess(U.decode({ type: true, foo: 'foo' }))
+    assertFailure(U.decode({ type: true, foo: 0 }), ['Invalid value 0 supplied to : U/0: A/foo: string'])
+    assertSuccess(U.decode({ type: false, bar: 0 }))
+    assertFailure(U.decode({ type: false, bar: 'bar' }), ['Invalid value "bar" supplied to : U/1: B/bar: number'])
+    assertFailure(U.decode({ type: 3 }), ['Invalid value 3 supplied to : U/type: true | false'])
+  })
+
+  it('should work when tag values are both strings and numbers with the same string representation', () => {
+    const A = t.type(
+      {
+        type: t.literal(1),
+        foo: t.string
+      },
+      'A'
+    )
+
+    const B = t.type(
+      {
+        type: t.literal('1'),
+        bar: t.number
+      },
+      'B'
+    )
+
+    const U = t.taggedUnion('type', [A, B], 'U')
+
+    assert.strictEqual(U.is({ type: 1, foo: 'foo' }), true)
+    assert.strictEqual(U.is({ type: 1, bar: 'bar' }), false)
+    assert.strictEqual(U.is({ type: '1', foo: 'foo' }), false)
+    assert.strictEqual(U.is({ type: '1', bar: 2 }), true)
+    assert.strictEqual(U.is({ type: 3 }), false)
+
+    assertSuccess(U.decode({ type: 1, foo: 'foo' }))
+    assertFailure(U.decode({ type: 1, bar: 'bar' }), ['Invalid value undefined supplied to : U/0: A/foo: string'])
+    assertSuccess(U.decode({ type: '1', bar: 2 }))
+    assertFailure(U.decode({ type: '1', foo: 'foo' }), ['Invalid value undefined supplied to : U/1: B/bar: number'])
+    assertFailure(U.decode({ type: 3 }), ['Invalid value 3 supplied to : U/type: 1 | "1"'])
   })
 })


### PR DESCRIPTION
… literals, fix #161

This PR adds support for numeric and boolean literal types to `taggedUnion`

/cc @corhere