### PR TITLE
New Feature: add `exact` combinator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
   "name": "io-ts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TypeScript compatible runtime type system for IO validation",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
     "lint": "tslint -p tsconfig.json src/**/*.ts test/**/*.ts",
-    "typings-checker": "typings-checker --allow-expect-error --project typings-checker/tsconfig.json typings-checker/index.ts",
+    "typings-checker":
+      "typings-checker --allow-expect-error --project typings-checker/tsconfig.json typings-checker/index.ts",
     "mocha": "cross-env TS_NODE_CACHE=false TS_NODE_PROJECT=test/tsconfig.json mocha -r ts-node/register test/*.ts",
-    "prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test}/**/*.ts\"",
-    "fix-prettier": "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test,examples,exercises}/**/*.ts\"",
+    "prettier":
+      "prettier --no-semi --single-quote --print-width 120 --parser typescript --list-different \"{src,test}/**/*.ts\"",
+    "fix-prettier":
+      "prettier --no-semi --single-quote --print-width 120 --parser typescript --write \"{src,test,examples,exercises}/**/*.ts\"",
     "test": "npm run prettier && npm run lint && npm run typings-checker && npm run mocha",
     "clean": "rimraf lib/*",
     "build": "npm run clean && tsc",
@@ -46,18 +47,6 @@
     "typescript": "2.8.3",
     "typings-checker": "1.1.2"
   },
-  "tags": [
-    "typescript",
-    "validation",
-    "inference",
-    "types",
-    "runtime"
-  ],
-  "keywords": [
-    "typescript",
-    "validation",
-    "inference",
-    "types",
-    "runtime"
-  ]
+  "tags": ["typescript", "validation", "inference", "types", "runtime"],
+  "keywords": ["typescript", "validation", "inference", "types", "runtime"]
 }

--- a/test/exact.ts
+++ b/test/exact.ts
@@ -1,0 +1,85 @@
+import * as t from '../src/index'
+import { assertSuccess, assertFailure, assertStrictEqual, DateFromNumber } from './helpers'
+import * as assert from 'assert'
+
+describe('exact', () => {
+  it('should succeed validating a valid value (type)', () => {
+    const T = t.exact(t.type({ foo: t.string }))
+    assertSuccess(T.decode({ foo: 'foo' }))
+  })
+
+  it('should succeed validating a valid value (partial)', () => {
+    const T = t.exact(t.partial({ foo: t.string }))
+    assertSuccess(T.decode({ foo: 'foo' }))
+    assertSuccess(T.decode({ foo: undefined }))
+    assertSuccess(T.decode({}))
+  })
+
+  it('should succeed validating a valid value (intersection)', () => {
+    const T = t.exact(t.intersection([t.type({ foo: t.string }), t.partial({ bar: t.number })]))
+    assertSuccess(T.decode({ foo: 'foo', bar: 1 }))
+    assertSuccess(T.decode({ foo: 'foo', bar: undefined }))
+    assertSuccess(T.decode({ foo: 'foo' }))
+  })
+
+  it('should succeed validating an undefined field', () => {
+    const T = t.exact(t.type({ foo: t.string, bar: t.union([t.string, t.undefined]) }))
+    assertSuccess(T.decode({ foo: 'foo' }))
+  })
+
+  it('should return the same reference if validation succeeded', () => {
+    const T = t.exact(t.type({ foo: t.string }))
+    const value = { foo: 'foo' }
+    assertStrictEqual(T.decode(value), value)
+  })
+
+  it('should fail validating an invalid value (type)', () => {
+    const T = t.exact(t.type({ foo: t.string }))
+    assertFailure(T.decode({ foo: 'foo', bar: 1, baz: true }), [
+      'Invalid value 1 supplied to : ExactType<{ foo: string }>/bar: never',
+      'Invalid value true supplied to : ExactType<{ foo: string }>/baz: never'
+    ])
+  })
+
+  it('should fail validating an invalid value (partial)', () => {
+    const T = t.exact(t.intersection([t.type({ foo: t.string }), t.partial({ bar: t.number })]))
+    assertFailure(T.decode({ foo: 'foo', baz: true }), [
+      'Invalid value true supplied to : ExactType<({ foo: string } & PartialType<{ bar: number }>)>/baz: never'
+    ])
+  })
+
+  it('should fail validating an invalid value (intersection)', () => {
+    const T = t.exact(t.partial({ foo: t.string }))
+    assertFailure(T.decode({ bar: 1 }), [
+      'Invalid value 1 supplied to : ExactType<PartialType<{ foo: string }>>/bar: never'
+    ])
+  })
+
+  it('should assign a default name', () => {
+    const T1 = t.exact(t.type({ foo: t.string }), 'Foo')
+    assert.strictEqual(T1.name, 'Foo')
+    const T2 = t.exact(t.type({ foo: t.string }))
+    assert.strictEqual(T2.name, 'ExactType<{ foo: string }>')
+  })
+
+  it('should serialize a deserialized', () => {
+    const T = t.exact(t.type({ a: DateFromNumber }))
+    assert.deepEqual(T.encode({ a: new Date(0) }), { a: 0 })
+  })
+
+  it('should return the same reference when serializing', () => {
+    const T = t.exact(t.type({ a: t.number }))
+    assert.strictEqual(T.encode, t.identity)
+  })
+
+  it('should type guard', () => {
+    const T1 = t.exact(t.type({ a: t.number }))
+    assert.strictEqual(T1.is({ a: 0 }), true)
+    assert.strictEqual(T1.is({ a: 0, b: 1 }), false)
+    assert.strictEqual(T1.is(undefined), false)
+    const T2 = t.exact(t.type({ a: DateFromNumber }))
+    assert.strictEqual(T2.is({ a: new Date(0) }), true)
+    assert.strictEqual(T2.is({ a: new Date(0), b: 1 }), false)
+    assert.strictEqual(T2.is(undefined), false)
+  })
+})

--- a/test/strictInterfaceWithOptionals.ts
+++ b/test/strictInterfaceWithOptionals.ts
@@ -7,24 +7,7 @@ export function strictInterfaceWithOptionals<R extends t.Props, O extends t.Prop
   optional: O,
   name?: string
 ): t.Type<t.TypeOfProps<R> & t.TypeOfPartialProps<O>, t.OutputOfProps<R> & t.OutputOfPartialProps<O>> {
-  const loose = t.intersection([t.interface(required), t.partial(optional)])
-  const props = Object.assign({}, required, optional)
-  return new t.Type(
-    name || `StrictInterfaceWithOptionals(${loose.name})`,
-    (m): m is t.TypeOfProps<R> & t.TypeOfPartialProps<O> =>
-      loose.is(m) && Object.getOwnPropertyNames(m).every(k => props.hasOwnProperty(k)),
-    (m, c) =>
-      loose.validate(m, c).chain(o => {
-        const errors: t.Errors = Object.getOwnPropertyNames(o)
-          .map(
-            key =>
-              !props.hasOwnProperty(key) ? t.getValidationError(o[key], t.appendContext(c, key, t.never)) : undefined
-          )
-          .filter((e): e is t.ValidationError => e !== undefined)
-        return errors.length ? t.failures(errors) : t.success(o)
-      }),
-    loose.encode
-  )
+  return t.exact(t.intersection([t.interface(required), t.partial(optional)]), name)
 }
 
 describe('strictInterfaceWithOptionals', () => {

--- a/test/taggedUnion.ts
+++ b/test/taggedUnion.ts
@@ -22,11 +22,11 @@ const TUB = t.intersection(
   'TUB'
 )
 
-const TUC = t.type(
-  {
+const TUC = t.exact(
+  t.type({
     type: t.literal('c'),
     baz: DateFromNumber
-  },
+  }),
   'TUC'
 )
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,7 +12,6 @@
     "strict": true,
     "target": "es5",
     "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "lib": ["es6"]
+    "forceConsistentCasingInFileNames": true
   }
 }

--- a/typings-checker/index.ts
+++ b/typings-checker/index.ts
@@ -367,3 +367,10 @@ const ActionType = pluck(Action, 'type')
 
 declare const Any1: t.AnyType | t.InterfaceType<any>
 Any1.decode(1)
+
+//
+// exact
+//
+
+declare const E1: t.InterfaceType<{ a: t.NumberType }, { a: number }, { a: number }, { a: number }>
+const E2: t.Type<any, any, { a: number }> = t.exact(E1)


### PR DESCRIPTION
`strict` is not flexible enough, this PR adds an `exact` combinator which is able to

> Is there a way to say "I want an object containing, optionally, any of these fields, but no other fields"? If you pass known optional fields, they are validated, and if you pass unknown fields they fail? t.strict requires fields to exist, and t.partial doesn't validate unknown

(https://twitter.com/nkariniemi/status/991396518082043905)

/cc @hoodunit

