### PR TITLE
add optional type and use it in partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ import * as t from 'io-ts'
 | function                  | `Function`                              | `t.Function`                                          |
 | literal                   | `'s'`                                   | `t.literal('s')`                                      |
 | partial                   | `Partial<{ name: string }>`             | `t.partial({ name: t.string })`                       |
+| optional                  | `A | undefined`                         | `t.optional(A)`                                       |
 | readonly                  | `Readonly<T>`                           | `t.readonly(T)`                                       |
 | readonly array            | `ReadonlyArray<number>`                 | `t.readonlyArray(t.number)`                           |
 | type alias                | `type A = { name: string }`             | `t.type({ name: t.string })`                          |

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ import * as t from 'io-ts'
 | function                  | `Function`                              | `t.Function`                                          |
 | literal                   | `'s'`                                   | `t.literal('s')`                                      |
 | partial                   | `Partial<{ name: string }>`             | `t.partial({ name: t.string })`                       |
-| optional                  | `A | undefined`                         | `t.optional(A)`                                       |
+| optional                  | `A \| undefined`                        | `t.optional(A)`                                       |
 | readonly                  | `Readonly<T>`                           | `t.readonly(T)`                                       |
 | readonly array            | `ReadonlyArray<number>`                 | `t.readonlyArray(t.number)`                           |
 | type alias                | `type A = { name: string }`             | `t.type({ name: t.string })`                          |

--- a/dtslint/index.ts
+++ b/dtslint/index.ts
@@ -133,6 +133,17 @@ const x22: P1T = {}
 const x23: P1T = { name: 's' }
 
 //
+// optional
+//
+
+const Opt1 = t.optional(t.number);
+type Opt1T = t.TypeOf<typeof Opt1> // $ExpectType number | undefined
+const opt1_ok_1: Opt1T = 123;
+const opt1_ok_2: Opt1T = undefined;
+// $ExpectError
+const opt1_bad_1: Opt1T = null;
+
+//
 // readonly
 //
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -641,10 +641,10 @@ export class OptionalType<RT extends Any, A = any, O = A, I = mixed> extends Typ
 export const optional = <RT extends Mixed>(
   type: RT,
   name: string = `(${type.name} | undefined)`
-): OptionalType<RT, TypeOf<RT['_A']>, OutputOf<RT['_A']>, mixed> => {
+): OptionalType<RT, TypeOf<RT> | undefined, OutputOf<RT> | undefined, InputOf<RT> | undefined> => {
   return new OptionalType(
     name,
-    (m): m is TypeOf<OptionalType<RT>['_A']> => type.is(m) || undefinedType.is(m),
+    (m): m is TypeOf<OptionalType<RT>> => type.is(m) || undefinedType.is(m),
     (m, c) => {
       const v = type.validate(m, c)
       return v.isLeft() && undefinedType.is(m) ? success(m) : v

--- a/test/optional.ts
+++ b/test/optional.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert'
+import * as t from '../src/index'
+import { assertSuccess, assertFailure, assertStrictEqual, DateFromNumber, withDefault } from './helpers'
+
+describe('optional', () => {
+  it('should succeed validating a valid value', () => {
+    const T = t.optional(t.number)
+    assertSuccess(T.decode(0))
+    assertSuccess(T.decode(1))
+    assertSuccess(T.decode(undefined))
+  })
+
+  it('should return the same reference if validation succeeded', () => {
+    const T = t.optional(t.Dictionary)
+    const value = {}
+    assertStrictEqual(T.decode(value), value)
+  })
+
+  it('should fail validating an invalid value', () => {
+    const T = t.optional(t.Integer)
+    assertFailure(T.decode('a'), ['Invalid value "a" supplied to : (Integer | undefined)'])
+    assertFailure(T.decode(1.2), ['Invalid value 1.2 supplied to : (Integer | undefined)'])
+  })
+
+  it('should serialize a deserialized', () => {
+    const T = t.optional(DateFromNumber)
+    assert.deepEqual(T.encode(new Date(0)), 0)
+    assert.deepEqual(T.encode(undefined), undefined)
+  })
+
+  it('should return the same reference when serializing', () => {
+    const T = t.optional(t.array(t.number))
+    assert.strictEqual(T.encode, t.identity)
+  })
+
+  it('should type guard', () => {
+    const T = t.optional(t.Integer)
+    assert.strictEqual(T.is(1.2), false)
+    assert.strictEqual(T.is('a'), false)
+    assert.strictEqual(T.is(1), true)
+    assert.strictEqual(T.is(undefined), true)
+  })
+
+  it('should assign a default name', () => {
+    const T1 = t.optional(t.number)
+    assert.strictEqual(T1.name, '(number | undefined)')
+    const T2 = t.optional(t.number, 'T2')
+    assert.strictEqual(T2.name, 'T2')
+  })
+})

--- a/test/optional.ts
+++ b/test/optional.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as t from '../src/index'
-import { assertSuccess, assertFailure, assertStrictEqual, DateFromNumber, withDefault } from './helpers'
+import { assertSuccess, assertFailure, assertStrictEqual, DateFromNumber } from './helpers'
 
 describe('optional', () => {
   it('should succeed validating a valid value', () => {

--- a/test/partial.ts
+++ b/test/partial.ts
@@ -41,8 +41,7 @@ describe('partial', () => {
   it('should fail validating an invalid value', () => {
     const T = t.partial({ a: t.number })
     assertFailure(T.decode({ a: 's' }), [
-      'Invalid value "s" supplied to : PartialType<{ a: number }>/a: (number | undefined)/0: number',
-      'Invalid value "s" supplied to : PartialType<{ a: number }>/a: (number | undefined)/1: undefined'
+      'Invalid value "s" supplied to : PartialType<{ a: number }>/a: (number | undefined)'
     ])
   })
 
@@ -88,5 +87,17 @@ describe('partial', () => {
     const T = t.partial({ a: DateFromNumber })
     const x = { a: new Date(0), b: 'foo' }
     assert.deepEqual(T.encode(x), { a: 0, b: 'foo' })
+  })
+
+  it('should report expected shallow validation error', () => {
+    const T = t.partial({ a: t.number }, 'T')
+    const x = { a: null }
+    assertFailure(T.decode(x), ['Invalid value null supplied to : T/a: (number | undefined)'])
+  })
+
+  it('should report expected deep validation error', () => {
+    const T = t.type({ a: t.partial({ b: t.type({ c: t.number }, 'Z') }, 'Y') }, 'X')
+    const x = { a: { b: { c: null } } }
+    assertFailure(T.decode(x), ['Invalid value null supplied to : X/a: Y/b: (Z | undefined)/c: number'])
   })
 })

--- a/test/strictInterfaceWithOptionals.ts
+++ b/test/strictInterfaceWithOptionals.ts
@@ -20,10 +20,7 @@ describe('strictInterfaceWithOptionals', () => {
   it('should fail validating an invalid value', () => {
     const T = strictInterfaceWithOptionals({ foo: t.string }, { bar: t.string }, 'T')
     assertFailure(T.decode({ foo: 'foo', a: 1 }), ['Invalid value 1 supplied to : T/a: never'])
-    assertFailure(T.decode({ foo: 'foo', bar: 1 }), [
-      'Invalid value 1 supplied to : T/bar: (string | undefined)/0: string',
-      'Invalid value 1 supplied to : T/bar: (string | undefined)/1: undefined'
-    ])
+    assertFailure(T.decode({ foo: 'foo', bar: 1 }), ['Invalid value 1 supplied to : T/bar: (string | undefined)'])
   })
 
   it('should return the same reference when serializing', () => {


### PR DESCRIPTION
The purpose of this change is to *not* expose "union type index" in validation errors when using partials (issue #195).

This is accomplished by adding a new optional type, which works like a union between a specified type and the undefined type, and using it instead of unions inside partials.