### PR TITLE
Use NonEmptyArray for representing validation errors

### DIFF
--- a/src/PathReporter.ts
+++ b/src/PathReporter.ts
@@ -1,5 +1,6 @@
 import { Reporter } from './Reporter'
 import { Context, getFunctionName, ValidationError } from './index'
+import { NonEmptyArray, nonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
 
 function stringify(v: any): string {
   return typeof v === 'function' ? getFunctionName(v) : JSON.stringify(v)
@@ -13,14 +14,14 @@ function getMessage(v: any, context: Context): string {
   return `Invalid value ${stringify(v)} supplied to ${getContextPath(context)}`
 }
 
-export function failure(es: Array<ValidationError>): Array<string> {
+export function failure(es: NonEmptyArray<ValidationError>): NonEmptyArray<string> {
   return es.map(e => getMessage(e.value, e.context))
 }
 
-export function success(): Array<string> {
-  return ['No errors!']
+export function success(): NonEmptyArray<string> {
+  return nonEmptyArray.of('No errors!')
 }
 
 export const PathReporter: Reporter<Array<string>> = {
-  report: validation => validation.fold(failure, success)
+  report: validation => validation.fold(failure, success).toArray()
 }

--- a/test/PathReporter.ts
+++ b/test/PathReporter.ts
@@ -10,7 +10,7 @@ describe('PathReporter', () => {
     assert.deepEqual(PathReporter.report(t.number.decode(function f() {})), ['Invalid value f supplied to : number'])
   })
 
-  it('should say something whene there are no errors', () => {
+  it('should say something when there are no errors', () => {
     assert.deepEqual(PathReporter.report(t.number.decode(1)), ['No errors!'])
   })
 })


### PR DESCRIPTION
As far as I can tell, if validation errors are present they should not be empty.

This PR replaces `Array<ValidationError>` with `NonEmptyArray<ValidationError>` whenever it makes sense.

Note that so far I've kept the `PathReporter` to return `Array<string>` because changing that would've been a breaking change in the APi.

I think it makes sense to do it, since as a user I would expect to be able to do stuff like `.head` on the errors, but I wanted to ask for feedback first.