### PR TITLE
failing test for keyof

### DIFF
--- a/dtslint/index.ts
+++ b/dtslint/index.ts
@@ -37,7 +37,7 @@ type Assert1 = t.TypeOf<typeof L1> // $ExpectType "a"
 
 const K1 = t.keyof({ a: true, b: true })
 type Assert2 = t.TypeOf<typeof K1> // $ExpectType "a" | "b"
-type Assert3 = typeof K1.keys // $ExpectType { a: "a", b: "b" }
+type KeyofKeys = typeof K1.keys // $ExpectType { a: "a", b: "b" }
 
 //
 // default types

--- a/dtslint/index.ts
+++ b/dtslint/index.ts
@@ -37,7 +37,7 @@ type Assert1 = t.TypeOf<typeof L1> // $ExpectType "a"
 
 const K1 = t.keyof({ a: true, b: true })
 type Assert2 = t.TypeOf<typeof K1> // $ExpectType "a" | "b"
-type KeyofKeys = typeof K1.keys // $ExpectType { a: "a", b: "b" }
+type KeyofKeys = typeof K1.keys // $ExpectType { a: "a"; b: "b"; }
 
 //
 // default types
@@ -88,7 +88,7 @@ const x11: I2T = { name: 'name', father: { surname: 'surname' } }
 //
 
 const D1 = t.dictionary(t.keyof({ a: true }), t.number)
-type Assert9 = t.TypeOf<typeof D1> // $ExpectType TypeOfDictionary<KeyofType<{ a: true; }>, NumberType>
+type Assert9 = t.TypeOf<typeof D1> // $ExpectType TypeOfDictionary<KeyofType<{ a: "a"; }>, NumberType>
 // $ExpectError
 const x12: t.TypeOf<typeof D1> = { a: 's' }
 // $ExpectError

--- a/dtslint/index.ts
+++ b/dtslint/index.ts
@@ -37,6 +37,7 @@ type Assert1 = t.TypeOf<typeof L1> // $ExpectType "a"
 
 const K1 = t.keyof({ a: true, b: true })
 type Assert2 = t.TypeOf<typeof K1> // $ExpectType "a" | "b"
+type Assert3 = typeof K1.keys // $ExpectType { a: "a", b: "b" }
 
 //
 // default types

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,10 +356,16 @@ export class KeyofType<D extends { [key: string]: mixed }> extends Type<keyof D>
 export const keyof = <D extends { [key: string]: mixed }>(
   keys: D,
   name: string = `(keyof ${JSON.stringify(Object.keys(keys))})`
-): KeyofType<: { [P in keyof D]: P }> => {
+): KeyofType<{ [P in keyof D]: P }> => {
   const is = (m: mixed): m is keyof D => string.is(m) && keys.hasOwnProperty(m)
   const keyMap = Object.keys(keys).reduce((map, next) => ({ ...map, [next]: next }), {} as any)
-  return new KeyofType(name, is, (m, c) => (is(m) ? success(m) : failure(m, c)), identity, keyMap)
+  return new KeyofType<{ [P in keyof D]: P }>(
+    name,
+    is,
+    (m, c) => (is(m) ? success(m) : failure(m, c)),
+    identity,
+    keyMap
+  )
 }
 
 //

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,9 +356,10 @@ export class KeyofType<D extends { [key: string]: mixed }> extends Type<keyof D>
 export const keyof = <D extends { [key: string]: mixed }>(
   keys: D,
   name: string = `(keyof ${JSON.stringify(Object.keys(keys))})`
-): KeyofType<D> => {
+): KeyofType<: { [P in keyof D]: P }> => {
   const is = (m: mixed): m is keyof D => string.is(m) && keys.hasOwnProperty(m)
-  return new KeyofType(name, is, (m, c) => (is(m) ? success(m) : failure(m, c)), identity, keys)
+  const keyMap = Object.keys(keys).reduce((map, next) => ({ ...map, [next]: next }), {} as any)
+  return new KeyofType(name, is, (m, c) => (is(m) ? success(m) : failure(m, c)), identity, keyMap)
 }
 
 //

--- a/test/keyof.ts
+++ b/test/keyof.ts
@@ -32,4 +32,9 @@ describe('keyof', () => {
     const T2 = t.keyof({ a: 1, b: 2 }, 'T2')
     assert.strictEqual(T2.name, 'T2')
   })
+  
+  it('should provide a key map', () => {
+    const T = t.keyOf({ a: 1, b: 2 })
+    assert.deepEqual(T.keys, { a: 'a', b: 'b' })
+  })
 })

--- a/test/keyof.ts
+++ b/test/keyof.ts
@@ -32,7 +32,7 @@ describe('keyof', () => {
     const T2 = t.keyof({ a: 1, b: 2 }, 'T2')
     assert.strictEqual(T2.name, 'T2')
   })
-  
+
   it('should provide a key map', () => {
     const T = t.keyOf({ a: 1, b: 2 })
     assert.deepEqual(T.keys, { a: 'a', b: 'b' })

--- a/test/keyof.ts
+++ b/test/keyof.ts
@@ -34,7 +34,7 @@ describe('keyof', () => {
   })
 
   it('should provide a key map', () => {
-    const T = t.keyOf({ a: 1, b: 2 })
+    const T = t.keyof({ a: 1, b: 2 })
     assert.deepEqual(T.keys, { a: 'a', b: 'b' })
   })
 })


### PR DESCRIPTION
I'd expect keys to be a dictionary of the actual keys, rather than the dictionary passed in. Since there's not a test for this I'm not sure what the intended behaviour is.

Todo:
- [ ] Follow up with a 'fix' to `KeyOfType` to make `.keys` return what this test is expecting