### PR TITLE
Bug Fix: dictionary type should not allow arrays, fix #218

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6291,9 +6291,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
+      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ts-jest": "22.4.2",
     "tslint": "5.9.1",
     "tslint-config-standard": "7.0.0",
-    "typescript": "^3.1.1"
+    "typescript": "^3.1.3"
   },
   "tags": [
     "typescript",

--- a/src/index.ts
+++ b/src/index.ts
@@ -643,17 +643,20 @@ export type TypeOfDictionary<D extends Any, C extends Any> = { [K in TypeOf<D>]:
 
 export type OutputOfDictionary<D extends Any, C extends Any> = { [K in OutputOf<D>]: OutputOf<C> }
 
+const refinedDictionary = refinement(Dictionary, d => Object.prototype.toString.call(d) === '[object Object]')
+
 export const dictionary = <D extends Mixed, C extends Mixed>(
   domain: D,
   codomain: C,
   name: string = `{ [K in ${domain.name}]: ${codomain.name} }`
-): DictionaryType<D, C, TypeOfDictionary<D, C>, OutputOfDictionary<D, C>, mixed> =>
-  new DictionaryType(
+): DictionaryType<D, C, TypeOfDictionary<D, C>, OutputOfDictionary<D, C>, mixed> => {
+  const isIndexSignatureRequired = (codomain as any) !== any
+  const D = isIndexSignatureRequired ? refinedDictionary : Dictionary
+  return new DictionaryType(
     name,
-    (m): m is TypeOfDictionary<D, C> =>
-      Dictionary.is(m) && Object.keys(m).every(k => domain.is(k) && codomain.is(m[k])),
+    (m): m is TypeOfDictionary<D, C> => D.is(m) && Object.keys(m).every(k => domain.is(k) && codomain.is(m[k])),
     (m, c) => {
-      const dictionaryValidation = Dictionary.validate(m, c)
+      const dictionaryValidation = D.validate(m, c)
       if (dictionaryValidation.isLeft()) {
         return dictionaryValidation
       } else {
@@ -701,6 +704,7 @@ export const dictionary = <D extends Mixed, C extends Mixed>(
     domain,
     codomain
   )
+}
 
 //
 // unions

--- a/test/default-types.ts
+++ b/test/default-types.ts
@@ -3,23 +3,20 @@ import * as t from '../src/index'
 import { assertSuccess, assertFailure } from './helpers'
 
 describe('Dictionary', () => {
-  it('should decode arrays', () => {
-    assertSuccess(t.Dictionary.decode([]))
-  })
-
-  it('should decode objects', () => {
+  it('should succeed validating a valid value', () => {
+    const T1 = t.Dictionary
     assertSuccess(t.Dictionary.decode({}))
+    assertSuccess(T1.decode([]))
+    assertSuccess(T1.decode([1]))
+    assertSuccess(T1.decode(new Number()))
+    assertSuccess(T1.decode(new Date()))
   })
 
-  it('should fail with primitives', () => {
+  it('should fail validating an invalid value', () => {
     const T = t.Dictionary
     assertFailure(T.decode('s'), ['Invalid value "s" supplied to : Dictionary'])
     assertFailure(T.decode(1), ['Invalid value 1 supplied to : Dictionary'])
     assertFailure(T.decode(true), ['Invalid value true supplied to : Dictionary'])
-  })
-
-  it('should fail with null and undefined', () => {
-    const T = t.Dictionary
     assertFailure(T.decode(null), ['Invalid value null supplied to : Dictionary'])
     assertFailure(T.decode(undefined), ['Invalid value undefined supplied to : Dictionary'])
   })

--- a/test/dictionary.ts
+++ b/test/dictionary.ts
@@ -13,6 +13,11 @@ describe('dictionary', () => {
     const T3 = t.dictionary(string2, t.number)
     assertSuccess(T3.decode({}))
     assertSuccess(T3.decode({ aa: 1 }))
+    const T4 = t.dictionary(t.string, t.any)
+    assertSuccess(T4.decode([]))
+    assertSuccess(T4.decode([1]))
+    assertSuccess(T4.decode(new Number()))
+    assertSuccess(T4.decode(new Date()))
   })
 
   it('should return the same reference if validation succeeded if nothing changed', () => {
@@ -31,9 +36,16 @@ describe('dictionary', () => {
   })
 
   it('should fail validating an invalid value', () => {
-    const T = t.dictionary(t.string, t.number)
-    assertFailure(T.decode(1), ['Invalid value 1 supplied to : { [K in string]: number }'])
-    assertFailure(T.decode({ aa: 's' }), ['Invalid value "s" supplied to : { [K in string]: number }/aa: number'])
+    const T1 = t.dictionary(t.string, t.number)
+    assertFailure(T1.decode(1), ['Invalid value 1 supplied to : { [K in string]: number }'])
+    assertFailure(T1.decode({ aa: 's' }), ['Invalid value "s" supplied to : { [K in string]: number }/aa: number'])
+    assertFailure(T1.decode([]), ['Invalid value [] supplied to : { [K in string]: number }'])
+    assertFailure(T1.decode([1]), ['Invalid value [1] supplied to : { [K in string]: number }'])
+    assertFailure(T1.decode(new Number()), ['Invalid value 0 supplied to : { [K in string]: number }'])
+    const d = new Date()
+    assertFailure(T1.decode(d), [`Invalid value ${JSON.stringify(d)} supplied to : { [K in string]: number }`])
+    const T2 = t.dictionary(string2, t.any)
+    assertFailure(T2.decode([1]), ['Invalid value "0" supplied to : { [K in string2]: any }/0: string2'])
   })
 
   it('should support literals as domain type', () => {


### PR DESCRIPTION
Unless the codomain is `any` (or `unknown`)

```ts
declare const as: Array<number>
declare const n: Number
declare const d: Date

const x1: Record<string, number> = as // error
const x2: Record<string, number> = n // error
const x3: Record<string, number> = d // error

const x4: { [key: string]: any } = as // ok
const x5: { [key: string]: any } = n // ok
const x6: { [key: string]: any } = d // ok
```

/cc @curledUpSheep

