### PR TITLE
Test: `Type.prototype.pipe` should accept a type with a narrower outp…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,13 @@ export class Type<A, O = A, I = mixed> implements Decoder<I, A>, Encoder<A, O> {
     readonly encode: Encode<A, O>
   ) {}
 
-  pipe<B, IB, A extends IB, OB extends A>(this: Type<A, O, I>, ab: Type<B, OB, IB>, name?: string): Type<B, O, I> {
+  pipe<B, IB, A extends IB, OB extends A>(
+    this: Type<A, O, I>,
+    ab: Type<B, OB, IB>,
+    name: string = `pipe(${this.name}, ${ab.name})`
+  ): Type<B, O, I> {
     return new Type(
-      name || `pipe(${this.name}, ${ab.name})`,
+      name,
       ab.is,
       (i, c) => {
         const validation = this.validate(i, c)

--- a/test/Type.ts
+++ b/test/Type.ts
@@ -37,10 +37,16 @@ describe('Type', () => {
       assert.strictEqual(t.string.pipe(t.string as t.Type<string, string, string>).encode, t.identity)
     })
 
-    it('accept to pipe to a Type with a wider input', () => {
+    it('accept to pipe a type with a wider input', () => {
       const T = t.string.pipe(t.string)
       assert.deepEqual(T.decode('a'), right('a'))
       assert.strictEqual(T.encode('a'), 'a')
+    })
+
+    it('accept to pipe a type with a narrower output', () => {
+      const T = t.string.pipe(t.literal('foo'))
+      assert.deepEqual(T.decode('foo'), right('foo'))
+      assert.strictEqual(T.encode('foo'), 'foo')
     })
   })
 


### PR DESCRIPTION
…ut, closes #230