### PR TITLE
encode last type in union (fixes #288)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1134,7 +1134,7 @@ export const union = <CS extends [Mixed, Mixed, ...Array<Mixed>]>(
       : a => {
           for (let i = 0; i < len - 1; i++) {
             const type = codecs[i]
-            if (type.is(a)) {
+            if ((isExactCodec(type) && type.type.is(a)) || type.is(a)) {
               return type.encode(a)
             }
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1138,7 +1138,7 @@ export const union = <CS extends [Mixed, Mixed, ...Array<Mixed>]>(
               return type.encode(a)
             }
           }
-          return a
+          return codecs[len - 1].encode(a)
         },
     codecs
   )

--- a/test/union.ts
+++ b/test/union.ts
@@ -80,6 +80,12 @@ describe('union', () => {
       assert.strictEqual(T1.encode(1), 1)
     })
 
+    it('should encode a prismatic value at last position', () => {
+      const T1 = t.union([t.number, t.type({ a: NumberFromString })])
+      assert.deepStrictEqual(T1.encode({ a: 1 }), { a: '1' })
+      assert.strictEqual(T1.encode(1), 1)
+    })
+
     it('should encode a nullary union', () => {
       const T0 = t.union([] as any)
       assert.strictEqual(T0.encode(1 as never), 1)

--- a/test/union.ts
+++ b/test/union.ts
@@ -100,6 +100,16 @@ describe('union', () => {
       const T = t.union([t.strict({ a: t.number }), t.type({ b: NumberFromString })])
       const x = { a: 1, c: true }
       assert.deepStrictEqual(T.encode(x), { a: 1 })
+      const y = { b: 1, d: 'a' }
+      assert.deepStrictEqual(T.encode(y), { b: '1', d: 'a' })
+    })
+
+    it('should play well with stripping combinators at last pos', () => {
+      const T = t.union([t.type({ b: NumberFromString }), t.strict({ a: t.number })])
+      const x = { a: 1, c: true }
+      assert.deepStrictEqual(T.encode(x), { a: 1 })
+      const y = { b: 1, d: 'a' }
+      assert.deepStrictEqual(T.encode(y), { b: '1', d: 'a' })
     })
   })
 

--- a/test/union.ts
+++ b/test/union.ts
@@ -99,7 +99,7 @@ describe('union', () => {
     it('should play well with stripping combinators', () => {
       const T = t.union([t.strict({ a: t.number }), t.type({ b: NumberFromString })])
       const x = { a: 1, c: true }
-      assert.deepStrictEqual(T.encode(x), x)
+      assert.deepStrictEqual(T.encode(x), { a: 1 })
     })
   })
 


### PR DESCRIPTION
I'm not happy with the solution as the fundamental problem remains.
However it's still better than the buggy situation in which both prismatic codec at last position and stripping combinators are failing.
@gcanti ok to make a quick fix release?
