### PR TITLE
Bug Fix: align the runtime behavior of `Exact.is` with the type system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 1.8.2
+
+- **Bug Fix**
+  - align the runtime behavior of `Exact.is` with the type system, fix #288 (@gcanti)
+
 # 1.8.1
 
 - **New Feature**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "TypeScript compatible runtime type system for IO validation",
   "files": [
     "lib"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1132,13 +1132,12 @@ export const union = <CS extends [Mixed, Mixed, ...Array<Mixed>]>(
     useIdentity(codecs, len)
       ? identity
       : a => {
-          for (let i = 0; i < len - 1; i++) {
-            const type = codecs[i]
-            if (type.is(a)) {
-              return type.encode(a)
+          for (let i = 0; i < len; i++) {
+            const codec = codecs[i]
+            if (codec.is(a)) {
+              return codec.encode(a)
             }
           }
-          return a
         },
     codecs
   )
@@ -1777,7 +1776,7 @@ export const exact = <C extends HasProps>(codec: C, name: string = getExactTypeN
   const props: Props = getProps(codec)
   return new ExactType(
     name,
-    (u): u is TypeOf<C> => codec.is(u) && Object.getOwnPropertyNames(u).every(k => hasOwnProperty.call(props, k)),
+    codec.is,
     (u, c) => {
       const unknownRecordValidation = UnknownRecord.validate(u, c)
       if (unknownRecordValidation.isLeft()) {

--- a/test/exact.ts
+++ b/test/exact.ts
@@ -19,14 +19,14 @@ describe('exact', () => {
     it('should check a isomorphic value', () => {
       const T = t.exact(t.type({ a: t.number }))
       assert.strictEqual(T.is({ a: 0 }), true)
-      assert.strictEqual(T.is({ a: 0, b: 1 }), false)
+      assert.strictEqual(T.is({ a: 0, b: 1 }), true)
       assert.strictEqual(T.is(undefined), false)
     })
 
     it('should check a prismatic value', () => {
       const T = t.exact(t.type({ a: NumberFromString }))
       assert.strictEqual(T.is({ a: 1 }), true)
-      assert.strictEqual(T.is({ a: 1, b: 1 }), false)
+      assert.strictEqual(T.is({ a: 1, b: 1 }), true)
       assert.strictEqual(T.is(undefined), false)
     })
   })

--- a/test/intersection.ts
+++ b/test/intersection.ts
@@ -32,11 +32,11 @@ describe('intersection', () => {
       assert.strictEqual(T.is({ a: 'a', b: 1 }), true)
     })
 
-    it('should fail when exact codecs are involved', () => {
+    it('should succeed when exact codecs are involved', () => {
       const A = t.exact(t.type({ a: t.string }))
       const B = t.exact(t.type({ b: t.number }))
       const T = t.intersection([A, B])
-      assert.strictEqual(T.is({ a: 'a', b: 1 }), false)
+      assert.strictEqual(T.is({ a: 'a', b: 1 }), true)
     })
   })
 

--- a/test/strict.ts
+++ b/test/strict.ts
@@ -19,14 +19,14 @@ describe('strict', () => {
     it('should check a isomorphic value', () => {
       const T = t.strict({ a: t.number })
       assert.strictEqual(T.is({ a: 0 }), true)
-      assert.strictEqual(T.is({ a: 0, b: 1 }), false)
+      assert.strictEqual(T.is({ a: 0, b: 1 }), true)
       assert.strictEqual(T.is(undefined), false)
     })
 
     it('should check a prismatic value', () => {
       const T = t.strict({ a: NumberFromString })
       assert.strictEqual(T.is({ a: 1 }), true)
-      assert.strictEqual(T.is({ a: 1, b: 1 }), false)
+      assert.strictEqual(T.is({ a: 1, b: 1 }), true)
       assert.strictEqual(T.is(undefined), false)
     })
   })

--- a/test/strictInterfaceWithOptionals.ts
+++ b/test/strictInterfaceWithOptionals.ts
@@ -49,6 +49,7 @@ describe('strictInterfaceWithOptionals', () => {
     const T = strictInterfaceWithOptionals({ foo: t.string }, { bar: t.string }, 'T')
     assert.strictEqual(T.is({ foo: 'foo' }), true)
     assert.strictEqual(T.is({ foo: 'foo', bar: 'a' }), true)
-    assert.strictEqual(T.is({ foo: 'foo', a: 1 }), false)
+    assert.strictEqual(T.is({ foo: 'foo', a: 1 }), true)
+    assert.strictEqual(T.is({ foo: 'foo', bar: 1 }), false)
   })
 })

--- a/test/union.ts
+++ b/test/union.ts
@@ -91,9 +91,26 @@ describe('union', () => {
     })
 
     it('should play well with stripping combinators', () => {
-      const T = t.union([t.strict({ a: t.number }), t.type({ b: NumberFromString })])
-      const x = { a: 1, c: true }
-      assert.deepStrictEqual(T.encode(x), x)
+      const x1 = { a: 1, c: true }
+      const x2 = { b: 2, c: true }
+
+      const T1 = t.union([t.strict({ a: t.number }), t.strict({ b: t.number })])
+      assert.deepStrictEqual(T1.encode({ a: 1 }), { a: 1 })
+      assert.deepStrictEqual(T1.encode({ b: 2 }), { b: 2 })
+      assert.deepStrictEqual(T1.encode(x1), { a: 1 })
+      assert.deepStrictEqual(T1.encode(x2), { b: 2 })
+
+      const T2 = t.union([t.strict({ a: t.number }), t.type({ b: NumberFromString })])
+      assert.deepStrictEqual(T2.encode({ a: 1 }), { a: 1 })
+      assert.deepStrictEqual(T2.encode({ b: 2 }), { b: '2' })
+      assert.deepStrictEqual(T2.encode(x1), { a: 1 })
+      assert.deepStrictEqual(T2.encode(x2), { b: '2', c: true })
+
+      const T3 = t.union([t.strict({ a: t.number }), t.strict({ b: NumberFromString })])
+      assert.deepStrictEqual(T3.encode({ a: 1 }), { a: 1 })
+      assert.deepStrictEqual(T3.encode({ b: 2 }), { b: '2' })
+      assert.deepStrictEqual(T3.encode(x1), { a: 1 })
+      assert.deepStrictEqual(T3.encode(x2), { b: '2' })
     })
   })
 


### PR DESCRIPTION
> only possibility would be to relax the `is` check of stripping combinators when testing for encoders

@sledorze you are right, for what concerns the `is` function, its runtime behavior **MUST** be aligned with the type system, so the proper fix of #288 is to relax its strictness. 

The same issue was already present for the deprecated `refinement`s (unions involving refinements could lead to wrong result of `encode`), while the `brand` combinator is not affected by this defect (runtime system and static system are aligned).

This change also fixes this [wrong test](https://github.com/gcanti/io-ts/blob/f1727c1edba4d03578832cd372969678fe543ea5/test/intersection.ts#L35) which should succeed. 