### PR TITLE
Add io-ts-promise to README.md community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ console.log(PathReporter.report(NumberFromString.decode('a')))
   io-ts
 - [graphql-to-io-ts](https://github.com/micimize/graphql-to-io-ts) - Generate typescript and cooresponding io-ts types from a graphql
   schema
+- [io-ts-promise](https://github.com/aeirola/io-ts-promise) - Convenience library for using io-ts with promise-based APIs
+
 
 # TypeScript integration
 


### PR DESCRIPTION
I wrote [io-ts-promise](https://github.com/aeirola/io-ts-promise) in order to make it simpler to use io-ts types at promise-based runtime boundary APIs. It was partially inspired by the discussion in #21, where the support for promises was proposed but rejected on the requirement that io-ts needs to stay synchronous.

In case the library would be useful to others as well, I'd propose to add it to the list of community packages.