### PR TITLE
fail fast if union encoding doesnt find a usable codec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1110,6 +1110,8 @@ export const union = <CS extends [Mixed, Mixed, ...Array<Mixed>]>(
               return codec.encode(a)
             }
           }
+
+          throw new Error(`no codec found to encode value in union type ${name}`)
         },
     codecs
   )

--- a/test/union.ts
+++ b/test/union.ts
@@ -112,6 +112,33 @@ describe('union', () => {
       assert.deepStrictEqual(T3.encode(x1), { a: 1 })
       assert.deepStrictEqual(T3.encode(x2), { b: '2' })
     })
+
+    it('should throw if none of the codecs are applicable', () => {
+      class DateT extends t.Type<Date, number> {
+        public readonly _tag: 'DateT' = 'DateT'
+
+        constructor() {
+          super(
+            'DateT',
+            (u): u is Date => u instanceof Date,
+            (u, c) => t.number.validate(u, c).map(n => new Date(n)),
+            a => a.valueOf()
+          )
+        }
+      }
+
+      const U1 = t.union([new DateT(), t.null])
+      const u1 = 'not the right thing' as any
+      let failed = false
+
+      try {
+        U1.encode(u1)
+      } catch (e) {
+        failed = true
+      }
+
+      assert.equal(failed, true)
+    })
   })
 
   it.skip('should optimize tagged unions', () => {


### PR DESCRIPTION
This is a bit of an edge case, but it sucked up a couple of man-hours in tracking down the root cause. We have a custom type `MyCustomType` that implements it's `is` function using `instanceof`:

```ts
import { DateTime } from "luxon";

// custom type impl...
  is: (v): v is DateTime => v instanceof DateTime,
// ...
```

When we used the type inside a union:

```ts
t.union([MyCustomType, t.null]).encode(myCustomTypeInstance)
```

...we got the result `undefined`. That seemed odd, as `undefined` was not one of the possible types.  Ultimately the issue was that the custom type was defined in project A, and the code invoking `encode` with `myCustomTypeInstance` was in project B. Project A had `luxon` version that was 1 patch higher than Project B, thus the `instanceof` check was failing. 

The code implementing `encode` in the union type just loops through the codecs looking for the first one whose `is` predicate returns true. The assumption is that there will be _at least one_ that matches,  which makes sense. However, due to our mismatching versions bug, we dropped out of `encode` without ever calling `return` and thus emitted `undefined`. 

I propose `throw`ing with a message that names the union to aid the human in debugging the issue.
