### PR TITLE
Polish: autobind decode method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 1.8.4
+
+- **Polish**
+  - autobind `decode` method (@gcanti)
+
 # 1.8.3
 
 - **Polish**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "TypeScript compatible runtime type system for IO validation",
   "files": [
     "lib"

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,9 @@ export class Type<A, O = A, I = unknown> implements Decoder<I, A>, Encoder<A, O>
     readonly validate: Validate<I, A>,
     /** converts a value of type A to a value of type O */
     readonly encode: Encode<A, O>
-  ) {}
+  ) {
+    this.decode = this.decode.bind(this)
+  }
 
   pipe<B, IB, A extends IB, OB extends A>(
     this: Type<A, O, I>,


### PR DESCRIPTION
This change makes easier to send around `decode` as a static function