### PR TITLE
target fp-ts#v2-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -86,9 +86,9 @@
       "dev": true
     },
     "@types/jest": {
-      "version": "23.3.8",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.8.tgz",
-      "integrity": "sha512-OKDxB/7woaQfUKkj+7+Zo3PmAxAYAy+SNwOwFhnYAc8JTaPhGOv8SC6QQg5D9+Giprhx/DzoKbJIpV9799VV0g==",
+      "version": "23.3.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.14.tgz",
+      "integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==",
       "dev": true
     },
     "@types/node": {
@@ -642,7 +642,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -989,12 +989,12 @@
       "dev": true
     },
     "bs-logger": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.5.tgz",
-      "integrity": "sha512-uFLE0LFMxrH8Z5Hd9QgivvRbrl/NFkOTHzGhlqQxsnmx5JBLrp4bc249afLL+GccyY/8hkcGi2LpVaOzaEY0nQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "dev": true,
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -1253,9 +1253,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true
     },
     "component-emitter": {
@@ -1720,34 +1720,13 @@
         "parsimmon": "^1.12.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "^5.12.0",
-        "typescript": "^3.4.0-dev.20190330"
+        "typescript": "^3.5.0-dev.20190502"
       },
       "dependencies": {
-        "tslint": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
-          "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.22.0",
-            "builtin-modules": "^1.1.1",
-            "chalk": "^2.3.0",
-            "commander": "^2.12.1",
-            "diff": "^3.2.0",
-            "glob": "^7.1.1",
-            "js-yaml": "^3.7.0",
-            "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
-            "resolve": "^1.3.2",
-            "semver": "^5.3.0",
-            "tslib": "^1.8.0",
-            "tsutils": "^2.29.0"
-          }
-        },
         "typescript": {
-          "version": "3.4.0-dev.20190330",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.0-dev.20190330.tgz",
-          "integrity": "sha512-w0LchV0iknmuvCbQ1EgqzUkeNZNvOznvbCwKaNZMOwGSOoE/jKxeswNfZGLerTScppmfCieQGAiGS9tRUvMBvg==",
+          "version": "3.5.0-dev.20190502",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.0-dev.20190502.tgz",
+          "integrity": "sha512-txMRX6xDYEDIjGxEBcnhGOY9EILoKobAS+FBH3bdSsq/GQugMR1CPr6mn+daMDW5pLDV+UmhsA3PndzHp3XODg==",
           "dev": true
         }
       }
@@ -2413,9 +2392,8 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.10.0.tgz",
-      "integrity": "sha512-ZOdfxiFgjipHEQKMam06/+BVneM/UKQDhoXAH2I6VvwqY4p0awswQcDgopvfE/jPeR7Aigv1aIv8U5awSXSw8A=="
+      "version": "github:gcanti/fp-ts#93001f8d87b0a658a02de5910e4c93877f285751",
+      "from": "github:gcanti/fp-ts#v2-lib"
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2463,7 +2441,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2484,12 +2463,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2504,17 +2485,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2631,7 +2615,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2643,6 +2628,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2657,6 +2643,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2664,12 +2651,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2688,6 +2677,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2768,7 +2758,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2780,6 +2771,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2865,7 +2857,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2901,6 +2894,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2920,6 +2914,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2963,12 +2958,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4404,7 +4401,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -4615,7 +4612,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -4642,7 +4639,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5128,7 +5125,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -5187,9 +5184,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
       "dev": true
     },
     "pretty-format": {
@@ -5334,7 +5331,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -5536,12 +5533,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -6305,7 +6302,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -6497,9 +6494,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "23.10.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.4.tgz",
-      "integrity": "sha512-oV/wBwGUS7olSk/9yWMiSIJWbz5xO4zhftnY3gwv6s4SMg6WHF1m8XZNBvQOKQRiTAexZ9754Z13dxBq3Zgssw==",
+      "version": "23.10.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.5.tgz",
+      "integrity": "sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -6508,6 +6505,7 @@
         "json5": "2.x",
         "make-error": "1.x",
         "mkdirp": "0.x",
+        "resolve": "1.x",
         "semver": "^5.5",
         "yargs-parser": "10.x"
       },
@@ -6523,7 +6521,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -6640,23 +6638,36 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
+      "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "tslint-config-standard": {
@@ -6736,9 +6747,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
-      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "uglify-js": {
@@ -7115,7 +7126,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "homepage": "https://github.com/gcanti/io-ts",
   "dependencies": {
-    "fp-ts": "^1.0.0"
+    "fp-ts": "github:gcanti/fp-ts#v2-lib"
   },
   "devDependencies": {
     "@types/benchmark": "1.0.31",
-    "@types/jest": "^23.3.8",
+    "@types/jest": "^23.3.14",
     "@types/node": "7.0.4",
     "benchmark": "2.1.4",
     "docs-ts": "0.0.1",
@@ -46,13 +46,13 @@
     "dtslint": "github:gcanti/dtslint",
     "jest": "^23.6.0",
     "mocha": "^5.2.0",
-    "prettier": "^1.15.3",
+    "prettier": "^1.17.0",
     "rimraf": "2.6.2",
-    "ts-jest": "^23.10.4",
+    "ts-jest": "^23.10.5",
     "ts-node": "^7.0.1",
-    "tslint": "^5.11.0",
+    "tslint": "^5.16.0",
     "tslint-config-standard": "^8.0.1",
-    "typescript": "^3.4.1"
+    "typescript": "^3.4.5"
   },
   "tags": [
     "typescript",

--- a/src/PathReporter.ts
+++ b/src/PathReporter.ts
@@ -1,5 +1,6 @@
 import { Reporter } from './Reporter'
 import { Context, getFunctionName, ValidationError } from './index'
+import { fold } from 'fp-ts/lib/Either'
 
 function stringify(v: any): string {
   if (typeof v === 'function') {
@@ -42,5 +43,5 @@ export function success(): Array<string> {
  * @since 1.0.0
  */
 export const PathReporter: Reporter<Array<string>> = {
-  report: validation => validation.fold(failure, success)
+  report: validation => fold(validation, failure, success)
 }

--- a/src/ThrowReporter.ts
+++ b/src/ThrowReporter.ts
@@ -3,6 +3,7 @@
  */
 import { Reporter } from './Reporter'
 import { PathReporter } from './PathReporter'
+import { isLeft } from 'fp-ts/lib/Either'
 
 /**
  * @since 1.0.0
@@ -10,7 +11,7 @@ import { PathReporter } from './PathReporter'
  */
 export const ThrowReporter: Reporter<void> = {
   report: validation => {
-    if (validation.isLeft()) {
+    if (isLeft(validation)) {
       throw PathReporter.report(validation).join('\n')
     }
   }


### PR DESCRIPTION
I know fp-ts v2 isn't baked yet, but I'm doing some monorepo investigation work and I need to get rid of fp-ts@<2 to prevent Typescript from exploding. I don't know what your plans are for io-ts & fp-ts@2 so it's up to you whether you use this branch.