### PR TITLE
Improve interactions between recursive and exact types.

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -22,8 +22,10 @@ parent: Modules
 - [Errors (interface)](#errors-interface)
 - [ExactC (interface)](#exactc-interface)
 - [~~FunctionC~~ (interface)](#functionc-interface)
+- [HasPropsExact (interface)](#haspropsexact-interface)
 - [HasPropsIntersection (interface)](#haspropsintersection-interface)
 - [HasPropsReadonly (interface)](#haspropsreadonly-interface)
+- [HasPropsRecursive (interface)](#haspropsrecursive-interface)
 - [HasPropsRefinement (interface)](#haspropsrefinement-interface)
 - [IntBrand (interface)](#intbrand-interface)
 - [IntersectionC (interface)](#intersectionc-interface)
@@ -321,6 +323,16 @@ export interface FunctionC extends FunctionType {}
 
 Added in v1.5.3
 
+# HasPropsExact (interface)
+
+**Signature**
+
+```ts
+export interface HasPropsExact extends ExactType<HasProps, any, any, any> {}
+```
+
+Added in v2.1.0
+
 # HasPropsIntersection (interface)
 
 **Signature**
@@ -340,6 +352,16 @@ export interface HasPropsReadonly extends ReadonlyType<HasProps, any, any, any> 
 ```
 
 Added in v1.1.0
+
+# HasPropsRecursive (interface)
+
+**Signature**
+
+```ts
+export interface HasPropsRecursive extends RecursiveType<HasProps, any, any, any> {}
+```
+
+Added in v2.1.0
 
 # HasPropsRefinement (interface)
 
@@ -798,6 +820,8 @@ export type HasProps =
   | HasPropsRefinement
   | HasPropsReadonly
   | HasPropsIntersection
+  | HasPropsRecursive
+  | HasPropsExact
   | InterfaceType<any, any, any, any>
   // tslint:disable-next-line: deprecation
   | StrictType<any, any, any, any>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "TypeScript compatible runtime type system for IO validation",
   "files": [
     "lib",


### PR DESCRIPTION
Currently, you can't create an `exact` `recursion` type.
 
`RecursiveType` doesn't satisfy the `HasProps` type, even if the type it's wrapping does. This is easy to fix by adding a `HasPropsRecursive` type to `HasProps` and then extending `getProps` to `return getProps(codec.type)` for recursive codecs.

But now we have another problem: calling `exact` on a `RecursiveType` forces the lazy evaluation that makes `RecursiveType` work. This causes issues if you're trying to have the `exact` be part of the recursion. For example, this fails because the function runs before `T` is defined:
```
const T = t.exact(t.recursion('T', () => t.partial({ rec: T })))
```

I fixed this by having `exact` delay its evaluation of `props` until forced by someone calling `validate` or `encode` on the result. I added some tests with a few more examples of things that didn't work before this pullreq.


Also, I bumped the version to 2.1.0 since I needed an `@since` for the new types.