### PR TITLE
Rewrite some type definition with strict index access

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -385,13 +385,7 @@ Added in v1.8.1
 **Signature**
 
 ```ts
-export interface IntersectionC<
-  CS extends
-    | [Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
->
+export interface IntersectionC<CS extends [Mixed, Mixed, ...Mixed[]]>
   extends IntersectionType<
     CS,
     CS extends [Mixed, Mixed]
@@ -639,14 +633,7 @@ Added in v1.5.3
 **Signature**
 
 ```ts
-export interface TupleC<
-  CS extends
-    | [Mixed, ...Mixed[]]
-    | [Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
->
+export interface TupleC<CS extends [Mixed, ...Mixed[]]>
   extends TupleType<
     CS,
     CS extends [Mixed]

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -385,25 +385,31 @@ Added in v1.8.1
 **Signature**
 
 ```ts
-export interface IntersectionC<CS extends [Mixed, Mixed, ...Array<Mixed>]>
+export interface IntersectionC<
+  CS extends
+    | [Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+>
   extends IntersectionType<
     CS,
-    CS extends { length: 2 }
+    CS extends [Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]>
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]>
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]> & TypeOf<CS[3]>
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]> & TypeOf<CS[3]> & TypeOf<CS[4]>
       : unknown,
-    CS extends { length: 2 }
+    CS extends [Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]>
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]>
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]> & OutputOf<CS[3]>
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]> & OutputOf<CS[3]> & OutputOf<CS[4]>
       : unknown,
     unknown
@@ -623,7 +629,7 @@ Added in v1.3.0
 
 ```ts
 export interface TaggedUnionC<Tag extends string, CS extends [Mixed, Mixed, ...Array<Mixed>]>  // tslint:disable-next-line: deprecation
-  extends TaggedUnionType<Tag, CS, TypeOf<CS[number]>, OutputOf<CS[number]>, unknown> {}
+  extends TaggedUnionType<Tag, CS, TypeOf<ElementOf<CS>>, OutputOf<ElementOf<CS>>, unknown> {}
 ```
 
 Added in v1.5.3
@@ -633,29 +639,36 @@ Added in v1.5.3
 **Signature**
 
 ```ts
-export interface TupleC<CS extends [Mixed, ...Array<Mixed>]>
+export interface TupleC<
+  CS extends
+    | [Mixed, ...Mixed[]]
+    | [Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+>
   extends TupleType<
     CS,
-    CS extends { length: 1 }
+    CS extends [Mixed]
       ? [TypeOf<CS[0]>]
-      : CS extends { length: 2 }
+      : CS extends [Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>]
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>]
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>, TypeOf<CS[3]>]
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>, TypeOf<CS[3]>, TypeOf<CS[4]>]
       : unknown,
-    CS extends { length: 1 }
+    CS extends [Mixed]
       ? [OutputOf<CS[0]>]
-      : CS extends { length: 2 }
+      : CS extends [Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>]
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>]
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>, OutputOf<CS[3]>]
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>, OutputOf<CS[3]>, OutputOf<CS[4]>]
       : unknown,
     unknown
@@ -691,7 +704,7 @@ Added in v1.5.3
 
 ```ts
 export interface UnionC<CS extends [Mixed, Mixed, ...Array<Mixed>]>
-  extends UnionType<CS, TypeOf<CS[number]>, OutputOf<CS[number]>, unknown> {}
+  extends UnionType<CS, TypeOf<ElementOf<CS>>, OutputOf<ElementOf<CS>>, unknown> {}
 ```
 
 Added in v1.5.3

--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -129,6 +129,10 @@ const Union3 = t.union([t.boolean, NumberFromString]) // $ExpectType UnionC<[Boo
 type Union3TypeTest = t.TypeOf<typeof Union3> // $ExpectType number | boolean
 type Union3OutputTest = t.OutputOf<typeof Union3> // $ExpectType string | boolean
 
+const UnionTup3 = t.union([t.boolean, t.number, t.literal('some_literal')]) // $ExpectType UnionC<[BooleanC, NumberC, LiteralC<"some_literal">]>
+type UnionTup3TypeTest = t.TypeOf<typeof UnionTup3> // $ExpectType number | boolean | "some_literal"
+type UnionTup3OutputTest = t.OutputOf<typeof UnionTup3> // $ExpectType number | boolean | "some_literal"
+
 //
 // intersection
 //

--- a/src/index.ts
+++ b/src/index.ts
@@ -1253,13 +1253,7 @@ export class IntersectionType<CS extends Array<Any>, A = any, O = A, I = unknown
 /**
  * @since 1.5.3
  */
-export interface IntersectionC<
-  CS extends
-    | [Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
->
+export interface IntersectionC<CS extends [Mixed, Mixed, ...Mixed[]]>
   extends IntersectionType<
     CS,
     CS extends [Mixed, Mixed]
@@ -1380,14 +1374,7 @@ export class TupleType<CS extends Array<Any>, A = any, O = A, I = unknown> exten
 /**
  * @since 1.5.3
  */
-export interface TupleC<
-  CS extends
-    | [Mixed, ...Mixed[]]
-    | [Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
-    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
->
+export interface TupleC<CS extends [Mixed, ...Mixed[]]>
   extends TupleType<
     CS,
     CS extends [Mixed]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1136,11 +1136,14 @@ export class UnionType<CS extends Array<Any>, A = any, O = A, I = unknown> exten
   }
 }
 
+// TODO: I'm not sure where the best place to place this is
+type ElementOf<T extends any[]> = T extends (infer R)[] ? R : never
+
 /**
  * @since 1.5.3
  */
 export interface UnionC<CS extends [Mixed, Mixed, ...Array<Mixed>]>
-  extends UnionType<CS, TypeOf<CS[number]>, OutputOf<CS[number]>, unknown> {}
+  extends UnionType<CS, TypeOf<ElementOf<CS>>, OutputOf<ElementOf<CS>>, unknown> {}
 
 const getUnionName = <CS extends [Mixed, Mixed, ...Array<Mixed>]>(codecs: CS): string => {
   return '(' + codecs.map(type => type.name).join(' | ') + ')'
@@ -1250,25 +1253,31 @@ export class IntersectionType<CS extends Array<Any>, A = any, O = A, I = unknown
 /**
  * @since 1.5.3
  */
-export interface IntersectionC<CS extends [Mixed, Mixed, ...Array<Mixed>]>
+export interface IntersectionC<
+  CS extends
+    | [Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+>
   extends IntersectionType<
     CS,
-    CS extends { length: 2 }
+    CS extends [Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]>
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]>
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]> & TypeOf<CS[3]>
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? TypeOf<CS[0]> & TypeOf<CS[1]> & TypeOf<CS[2]> & TypeOf<CS[3]> & TypeOf<CS[4]>
       : unknown,
-    CS extends { length: 2 }
+    CS extends [Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]>
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]>
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]> & OutputOf<CS[3]>
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? OutputOf<CS[0]> & OutputOf<CS[1]> & OutputOf<CS[2]> & OutputOf<CS[3]> & OutputOf<CS[4]>
       : unknown,
     unknown
@@ -1371,29 +1380,36 @@ export class TupleType<CS extends Array<Any>, A = any, O = A, I = unknown> exten
 /**
  * @since 1.5.3
  */
-export interface TupleC<CS extends [Mixed, ...Array<Mixed>]>
+export interface TupleC<
+  CS extends
+    | [Mixed, ...Mixed[]]
+    | [Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+    | [Mixed, Mixed, Mixed, Mixed, Mixed, ...Mixed[]]
+>
   extends TupleType<
     CS,
-    CS extends { length: 1 }
+    CS extends [Mixed]
       ? [TypeOf<CS[0]>]
-      : CS extends { length: 2 }
+      : CS extends [Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>]
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>]
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>, TypeOf<CS[3]>]
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? [TypeOf<CS[0]>, TypeOf<CS[1]>, TypeOf<CS[2]>, TypeOf<CS[3]>, TypeOf<CS[4]>]
       : unknown,
-    CS extends { length: 1 }
+    CS extends [Mixed]
       ? [OutputOf<CS[0]>]
-      : CS extends { length: 2 }
+      : CS extends [Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>]
-      : CS extends { length: 3 }
+      : CS extends [Mixed, Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>]
-      : CS extends { length: 4 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>, OutputOf<CS[3]>]
-      : CS extends { length: 5 }
+      : CS extends [Mixed, Mixed, Mixed, Mixed, Mixed]
       ? [OutputOf<CS[0]>, OutputOf<CS[1]>, OutputOf<CS[2]>, OutputOf<CS[3]>, OutputOf<CS[4]>]
       : unknown,
     unknown
@@ -1582,7 +1598,7 @@ export class TaggedUnionType<
  * @deprecated
  */
 export interface TaggedUnionC<Tag extends string, CS extends [Mixed, Mixed, ...Array<Mixed>]>  // tslint:disable-next-line: deprecation
-  extends TaggedUnionType<Tag, CS, TypeOf<CS[number]>, OutputOf<CS[number]>, unknown> {}
+  extends TaggedUnionType<Tag, CS, TypeOf<ElementOf<CS>>, OutputOf<ElementOf<CS>>, unknown> {}
 
 /**
  * Use `union` instead


### PR DESCRIPTION
Great package, I've been testing it on some internal lambda functions and it seems to make interfaces much safer.
I'm not sure if the current commit will align with the direction of the package but I would really appreciate if you would take it into consideration.

So the problem, as you may know, is that:
```ts
const arr: number[] = [];
const num: number = arr[0];
```
Is completely valid and TS will not show any errors even though it is clearly incorrect.
This problem is discussed here: https://github.com/microsoft/TypeScript/issues/13778

In our project, we're starting to try out this approach by using `patch-package` to minimize any possible run-time errors.
Basically changing:
```ts
interface Array {
// ...
  [n: number]: T;
}
```
to
```ts
interface Array {
// ...
  [n: number]: T | undefined;
}
```

Unfortunately I noticed that our branch on which `io-ts` is used there are some type errors created by this change. TS cannot infer that checking that given `arr.length > 1` implies `arr: [T, T, ...T[]]`. 

So things like:
```ts
export interface IntersectionC<
// ...
CS extends { length: 2 }
      ? TypeOf<CS[0]> & TypeOf<CS[1]>
// ...
```
Could not be proven to TS as correct.
All this commit does is change some problematic definition to the following form:
```ts
export interface IntersectionC<
// ...
CS extends [Mixed, Mixed]
      ? TypeOf<CS[0]> & TypeOf<CS[1]>
// ...
```

At times this requires writing more code since TS doesn't have higher-order types but I think this is a small change that would be greatly appreciated by us.
