### PR TITLE
Handle missing properties correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "2.0.6",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2217,7 +2217,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2241,13 +2242,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2264,19 +2267,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2407,7 +2413,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2421,6 +2428,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2437,6 +2445,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2445,13 +2454,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2472,6 +2483,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2560,7 +2572,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2574,6 +2587,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2669,7 +2683,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2711,6 +2726,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2732,6 +2748,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2780,13 +2797,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -798,7 +798,7 @@ export const type = <P extends Props>(props: P, name: string = getInterfaceTypeN
       if (UnknownRecord.is(u)) {
         for (let i = 0; i < len; i++) {
           const k = keys[i]
-          if (!types[i].is(u[k])) {
+          if (!(k in u) || !types[i].is(u[k])) {
             return false
           }
         }
@@ -814,12 +814,15 @@ export const type = <P extends Props>(props: P, name: string = getInterfaceTypeN
           const k = keys[i]
           const ak = a[k]
           const type = types[i]
-          const result = type.validate(ak, appendContext(c, k, type, ak))
+          const result =
+            ak === undefined && !(k in a)
+              ? failure(ak, appendContext(c, k, type, ak))
+              : type.validate(ak, appendContext(c, k, type, ak))
           if (isLeft(result)) {
             pushAll(errors, result.left)
           } else {
             const vak = result.right
-            if (vak !== ak || (vak === undefined && !hasOwnProperty.call(a, k))) {
+            if (vak !== ak || (vak === undefined && !(k in a))) {
               /* istanbul ignore next */
               if (a === o) {
                 a = { ...o }

--- a/test/exact.ts
+++ b/test/exact.ts
@@ -64,7 +64,7 @@ describe('exact', () => {
 
     it('should succeed validating an undefined field', () => {
       const T = t.exact(t.type({ foo: t.string, bar: t.union([t.string, t.undefined]) }))
-      assertSuccess(T.decode({ foo: 'foo' }))
+      assertSuccess(T.decode({ foo: 'foo', bar: undefined }))
     })
 
     it('should return the same reference if validation succeeded', () => {

--- a/test/recursion.ts
+++ b/test/recursion.ts
@@ -71,12 +71,16 @@ describe('recursion', () => {
       assertStrictEqual(T.decode(value), value)
     })
 
-    it('should fail validating an invalid value', () => {
+    it('should fail validating { a: number, b: ( self | undefined | null) } for value 1', () => {
       assertFailure(T, 1, ['Invalid value 1 supplied to : T'])
+    })
+    it('should fail validating { a: number, b: ( self | undefined | null) } for value {}', () => {
       assertFailure(T, {}, [
         'Invalid value undefined supplied to : T/a: number',
         'Invalid value undefined supplied to : T/b: (T | undefined | null)'
       ])
+    })
+    it('should fail validating { a: number, b: ( self | undefined | null) } for value { a: 1, b: {} }', () => {
       assertFailure(T, { a: 1, b: {} }, [
         'Invalid value undefined supplied to : T/b: (T | undefined | null)/0: T/a: number',
         'Invalid value undefined supplied to : T/b: (T | undefined | null)/0: T/b: (T | undefined | null)',

--- a/test/recursion.ts
+++ b/test/recursion.ts
@@ -73,9 +73,13 @@ describe('recursion', () => {
 
     it('should fail validating an invalid value', () => {
       assertFailure(T, 1, ['Invalid value 1 supplied to : T'])
-      assertFailure(T, {}, ['Invalid value undefined supplied to : T/a: number'])
+      assertFailure(T, {}, [
+        'Invalid value undefined supplied to : T/a: number',
+        'Invalid value undefined supplied to : T/b: (T | undefined | null)'
+      ])
       assertFailure(T, { a: 1, b: {} }, [
         'Invalid value undefined supplied to : T/b: (T | undefined | null)/0: T/a: number',
+        'Invalid value undefined supplied to : T/b: (T | undefined | null)/0: T/b: (T | undefined | null)',
         'Invalid value {} supplied to : T/b: (T | undefined | null)/1: undefined',
         'Invalid value {} supplied to : T/b: (T | undefined | null)/2: null'
       ])

--- a/test/strict.ts
+++ b/test/strict.ts
@@ -30,7 +30,7 @@ describe('strict', () => {
       assert.strictEqual(T.is(undefined), false)
     })
 
-    it('#423', () => {
+    it('should allow properties to be satisified by getters - #423', () => {
       class A {
         get a() {
           return 'a'
@@ -52,7 +52,7 @@ describe('strict', () => {
 
     it('should succeed validating an undefined field', () => {
       const T = t.strict({ foo: t.string, bar: t.union([t.string, t.undefined]) })
-      assertSuccess(T.decode({ foo: 'foo' }))
+      assertSuccess(T.decode({ foo: 'foo', bar: undefined }))
     })
 
     it('should return the same reference if validation succeeded', () => {

--- a/test/type.ts
+++ b/test/type.ts
@@ -18,115 +18,139 @@ describe('type', () => {
   })
 
   const successCases = [
-    // [ props, value ]
-    [{ a: t.null }, { a: null }],
-    [{ a: t.nullType }, { a: null }],
-    [{ a: t.undefined }, { a: undefined }],
-    [{ a: t.void }, { a: undefined }],
-    [{ a: t.voidType }, { a: undefined }],
-    [{ a: t.unknown }, { a: 'a' }],
-    [{ a: t.unknown }, { a: undefined }],
-    [{ a: t.string }, { a: 'a' }],
-    [{ a: t.number }, { a: Number.MAX_VALUE }],
-    [{ a: t.bigint }, { a: BigInt(Number.MAX_VALUE + 1), toJSON: () => `a: BigInt(Number.MAX_VALUE +1)` }],
-    [{ a: t.boolean }, { a: true }],
-    [{ a: t.UnknownArray }, { a: [[1], [2]] }],
-    [{ a: t.UnknownArray }, { a: [] }],
-    [{ a: t.UnknownArray }, { a: [undefined] }],
-    [{ a: t.UnknownArray }, { a: [[undefined], [2]] }],
-    [{ a: t.array(t.number) }, { a: [1, 2] }],
-    [{ a: t.UnknownRecord }, { a: { b: 'b' } }],
-    [{ a: t.UnknownRecord }, { a: {} }],
-    [{ a: t.UnknownRecord }, { a: { undefined } }],
-    [{ a: t.UnknownRecord }, { a: { b: undefined } }],
-    [{ a: t.record(t.string, t.string) }, { a: { b: 'b' } }],
-    [{ a: t.Int }, { a: -1 }],
-    [{ a: t.literal('YES') }, { a: 'YES' }],
-    [{ a: t.partial({ b: t.string, c: t.string }) }, { a: {} }],
-    [{ a: t.partial({ b: t.string, c: t.string }) }, { a: { b: undefined, c: undefined } }],
-    [{ a: t.readonly(t.number) }, { a: 1 }],
-    [{ a: t.readonlyArray(t.number) }, { a: [1, 2] }],
-    [{ a: t.type({ b: t.string, c: t.string }) }, { a: { b: 'b', c: 'c' } }],
-    [{ a: t.tuple([t.string, t.string]) }, { a: ['A', 'B'] }],
+    // [ props, name, value ]
+    [{ a: t.null }, undefined, { a: null }],
+    [{ a: t.nullType }, undefined, { a: null }],
+    [{ a: t.undefined }, undefined, { a: undefined }],
+    [{ a: t.void }, undefined, { a: undefined }],
+    [{ a: t.voidType }, undefined, { a: undefined }],
+    [{ a: t.unknown }, undefined, { a: 'a' }],
+    [{ a: t.unknown }, undefined, { a: undefined }],
+    [{ a: t.string }, undefined, { a: 'a' }],
+    [{ a: t.number }, undefined, { a: Number.MAX_VALUE }],
+    [{ a: t.bigint }, undefined, { a: BigInt(Number.MAX_VALUE + 1), toJSON: () => `a: BigInt(Number.MAX_VALUE +1)` }],
+    [{ a: t.boolean }, undefined, { a: true }],
+    [{ a: t.UnknownArray }, undefined, { a: [[1], [2]] }],
+    [{ a: t.UnknownArray }, undefined, { a: [] }],
+    [{ a: t.UnknownArray }, undefined, { a: [undefined] }],
+    [{ a: t.UnknownArray }, undefined, { a: [[undefined], [2]] }],
+    [{ a: t.array(t.number) }, 'Array<number>', { a: [1, 2] }],
+    [{ a: t.UnknownRecord }, undefined, { a: { b: 'b' } }],
+    [{ a: t.UnknownRecord }, undefined, { a: {} }],
+    [{ a: t.UnknownRecord }, undefined, { a: { undefined } }],
+    [{ a: t.UnknownRecord }, undefined, { a: { b: undefined } }],
+    [{ a: t.record(t.string, t.string) }, '{ a: { [K in string]: string } }', { a: { b: 'b' } }],
+    [{ a: t.Int }, '{ a: Int }', { a: -1 }],
+    [{ a: t.literal('YES') }, '{ a: "YES" }', { a: 'YES' }],
+    [{ a: t.partial({ b: t.string, c: t.string }) }, '{ a: Partial<{ b: string, c:string }> }', { a: {} }],
+    [
+      { a: t.partial({ b: t.string, c: t.string }) }, 
+      '{ a: Partial<{ b: string, c: string }> }', 
+      { a: { b: 'b', c: undefined } }
+    ],
+    [{ a: t.readonly(t.number) }, '{ a: Readonly<number> }', { a: 1 }],
+    [{ a: t.readonlyArray(t.number) }, '{ a: ReadonlyArray<number> }', { a: [1, 2] }],
+    [{ a: t.type({ b: t.string, c: t.string }) }, '{ a: { b: string, c: string }', { a: { b: 'b', c: 'c' } }],
+    [{ a: t.tuple([t.string, t.string]) }, '{ a: [string, string] }', { a: ['A', 'B'] }],
     [
       { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
+      '{ a: (string | number), b: (string | number) }',
       { a: 1, b: 'b' }
     ],
-    [{ a: t.intersection([t.number, t.Int]) }, { a: 1 }],
+    [{ a: t.intersection([t.number, t.Int]) }, '{ a: (number & Int) }', { a: 1 }],
     [
       { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
+      '{ a: Positive }', 
       { a: 1 }
     ],
-    [{ a: t.keyof({ foo: null, bar: null }) }, { a: 'foo' }],
-    [{ a: t.exact(t.type({ x: t.number, y: t.number })) }, { a: { x: 1, y: 2, z: 3 } }],
-    [{ a: t.strict({ x: t.number, y: t.number }) }, { a: { x: 1, y: 2, z: 3 } }]
+    [{ a: t.keyof({ foo: null, bar: null }) }, '{ a: "foo" | "bar" }', { a: 'foo' }],
+    [
+      { a: t.exact(t.type({ x: t.number, y: t.number })) }, 
+      '{ a: {| x: number, y: number |} }', 
+      { a: { x: 1, y: 2, z: 3 } }],
+    [
+      { a: t.strict({ x: t.number, y: t.number }) }, 
+      '{ a: {| x: number, y: number |} }', 
+      { a: { x: 1, y: 2, z: 3 } }]
   ]
 
   describe('`is` should return `true` for', () => {
-    test.each(successCases)(`props %j given valid input %j`, (props, value) => {
-      const T = t.type(props)
+    test.each(successCases)('props: %p, name: %p given valid input %j', (props, name, value) => {
+      const T = t.type(props, name)
       assert.strictEqual(T.is(value), true)
     })
   })
 
+  describe('`decode` should succeed decoding with', () => {
+    test.each(successCases)('props: %p, name: %p, value: %j', (props, name, value) => {
+      const T = t.type(props, name)
+      assertSuccess(T.decode(value))
+    })
+  })
+
   const failureCases = [
-    // [ props, value, messages ]
-    [{ a: t.null }, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
-    [{ a: t.null }, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
-    [{ a: t.null }, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
-    [{ a: t.nullType }, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
-    [{ a: t.nullType }, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
-    [{ a: t.nullType }, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
-    [{ a: t.undefined }, { a: 'a' }, ['Invalid value "a" supplied to : { a: undefined }/a: undefined']],
-    [{ a: t.undefined }, {}, ['Invalid value undefined supplied to : { a: undefined }/a: undefined']],
-    [{ a: t.void }, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
-    [{ a: t.void }, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
-    [{ a: t.voidType }, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
-    [{ a: t.voidType }, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
-    [{ a: t.unknown }, {}, ['Invalid value undefined supplied to : { a: unknown }/a: unknown']],
-    [{ a: t.string }, 1, ['Invalid value 1 supplied to : { a: string }']],
-    [{ a: t.string }, {}, ['Invalid value undefined supplied to : { a: string }/a: string']],
-    [{ a: t.string }, { a: undefined }, ['Invalid value undefined supplied to : { a: string }/a: string']],
-    [{ a: t.string }, { a: 1 }, ['Invalid value 1 supplied to : { a: string }/a: string']],
-    [{ a: t.string }, [], ['Invalid value [] supplied to : { a: string }']], // #407
-    [{ a: t.number }, { a: 'a' }, ['Invalid value "a" supplied to : { a: number }/a: number']],
-    [{ a: t.number }, {}, ['Invalid value undefined supplied to : { a: number }/a: number']],
-    [{ a: t.bigint }, { a: 'a' }, ['Invalid value "a" supplied to : { a: bigint }/a: bigint']],
-    [{ a: t.bigint }, {}, ['Invalid value undefined supplied to : { a: bigint }/a: bigint']],
-    [{ a: t.boolean }, { a: 1 }, ['Invalid value 1 supplied to : { a: boolean }/a: boolean']],
-    [{ a: t.boolean }, {}, ['Invalid value undefined supplied to : { a: boolean }/a: boolean']],
-    [{ a: t.UnknownArray }, { a: 'a' }, ['Invalid value "a" supplied to : { a: UnknownArray }/a: UnknownArray']],
-    [{ a: t.UnknownArray }, {}, ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']],
+    // [ props, name, value, messages ]
+    [{ a: t.null }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
+    [{ a: t.null }, undefined, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.null }, undefined, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.nullType }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
+    [{ a: t.nullType }, undefined, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.nullType }, undefined, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.undefined }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: undefined }/a: undefined']],
+    [{ a: t.undefined }, undefined, {}, ['Invalid value undefined supplied to : { a: undefined }/a: undefined']],
+    [{ a: t.void }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
+    [{ a: t.void }, undefined, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
+    [{ a: t.voidType }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
+    [{ a: t.voidType }, undefined, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
+    [{ a: t.unknown }, undefined, {}, ['Invalid value undefined supplied to : { a: unknown }/a: unknown']],
+    [{ a: t.string }, undefined, 1, ['Invalid value 1 supplied to : { a: string }']],
+    [{ a: t.string }, undefined, {}, ['Invalid value undefined supplied to : { a: string }/a: string']],
+    [{ a: t.string }, undefined, { a: undefined }, ['Invalid value undefined supplied to : { a: string }/a: string']],
+    [{ a: t.string }, undefined, { a: 1 }, ['Invalid value 1 supplied to : { a: string }/a: string']],
+    [{ a: t.string }, undefined, [], ['Invalid value [] supplied to : { a: string }']], // #407
+    [{ a: t.number }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: number }/a: number']],
+    [{ a: t.number }, undefined, {}, ['Invalid value undefined supplied to : { a: number }/a: number']],
+    [{ a: t.bigint }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: bigint }/a: bigint']],
+    [{ a: t.bigint }, undefined, {}, ['Invalid value undefined supplied to : { a: bigint }/a: bigint']],
+    [{ a: t.boolean }, undefined, { a: 1 }, ['Invalid value 1 supplied to : { a: boolean }/a: boolean']],
+    [{ a: t.boolean }, undefined, {}, ['Invalid value undefined supplied to : { a: boolean }/a: boolean']],
+    [{ a: t.UnknownArray }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: UnknownArray }/a: UnknownArray']],
+    [{ a: t.UnknownArray }, undefined, {}, ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']],
     [
       { a: t.UnknownArray },
+      undefined, 
       { a: undefined },
       ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']
     ],
-    [{ a: t.array(t.number) }, { a: 1 }, ['Invalid value 1 supplied to : { a: Array<number> }/a: Array<number>']],
-    [{ a: t.array(t.number) }, {}, ['Invalid value undefined supplied to : { a: Array<number> }/a: Array<number>']],
-    [{ a: t.UnknownRecord }, { a: [1] }, ['Invalid value [1] supplied to : { a: UnknownRecord }/a: UnknownRecord']],
-    [{ a: t.UnknownRecord }, {}, ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']],
+    [{ a: t.array(t.number) }, '{ a: Array<number> }', { a: 1 }, ['Invalid value 1 supplied to : { a: Array<number> }/a: Array<number>']],
+    [{ a: t.array(t.number) }, '{ a: Array<number> }', {}, ['Invalid value undefined supplied to : { a: Array<number> }/a: Array<number>']],
+    [{ a: t.UnknownRecord }, undefined, { a: [1] }, ['Invalid value [1] supplied to : { a: UnknownRecord }/a: UnknownRecord']],
+    [{ a: t.UnknownRecord }, undefined, {}, ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']],
     [
       { a: t.UnknownRecord },
+      undefined, 
       { a: undefined },
       ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']
     ],
     [
       { a: t.record(t.string, t.string) },
+      '{ a: { [K in string]: string } }', 
       { a: 1 },
       ['Invalid value 1 supplied to : { a: { [K in string]: string } }/a: { [K in string]: string }']
     ],
     [
       { a: t.record(t.string, t.string) },
+      '{ a: { [K in string]: string } }', 
       {},
       ['Invalid value undefined supplied to : { a: { [K in string]: string } }/a: { [K in string]: string }']
     ],
-    [{ a: t.Int }, { a: -1.1 }, ['Invalid value -1.1 supplied to : { a: Int }/a: Int']],
-    [{ a: t.Int }, {}, ['Invalid value undefined supplied to : { a: Int }/a: Int']],
-    [{ a: t.literal('YES') }, { a: 'NO' }, ['Invalid value "NO" supplied to : { a: "YES" }/a: "YES"']],
-    [{ a: t.literal('YES') }, {}, ['Invalid value undefined supplied to : { a: "YES" }/a: "YES"']],
+    [{ a: t.Int }, '{ a: Int }', { a: -1.1 }, ['Invalid value -1.1 supplied to : { a: Int }/a: Int']],
+    [{ a: t.Int }, '{ a: Int }', {}, ['Invalid value undefined supplied to : { a: Int }/a: Int']],
+    [{ a: t.literal('YES') }, '{ a: "YES" }', { a: 'NO' }, ['Invalid value "NO" supplied to : { a: "YES" }/a: "YES"']],
+    [{ a: t.literal('YES') }, '{ a: "YES" }', {}, ['Invalid value undefined supplied to : { a: "YES" }/a: "YES"']],
     [
       { a: t.partial({ b: t.string, c: t.string }) },
+      '{ a: Partial<{ b: string, c: string }> }', 
       { a: { b: 1 } },
       [
         'Invalid value 1 supplied to : ' +
@@ -135,6 +159,7 @@ describe('type', () => {
     ],
     [
       { a: t.partial({ b: t.string, c: t.string }) },
+      '{ a: Partial<{ b: string, c: string }> }', 
       {},
       [
         'Invalid value undefined supplied to : ' +
@@ -143,26 +168,31 @@ describe('type', () => {
     ],
     [
       { a: t.readonly(t.number) },
+      '{ a: Readonly<number> }', 
       { a: 'a' },
       ['Invalid value "a" supplied to : { a: Readonly<number> }/a: Readonly<number>']
     ],
     [
       { a: t.readonly(t.number) },
+      '{ a: Readonly<number> }', 
       {},
       ['Invalid value undefined supplied to : { a: Readonly<number> }/a: Readonly<number>']
     ],
     [
       { a: t.readonlyArray(t.number) },
+      '{ a: ReadonlyArray<number> }', 
       { a: 1 },
       ['Invalid value 1 supplied to : { a: ReadonlyArray<number> }/a: ReadonlyArray<number>']
     ],
     [
       { a: t.readonlyArray(t.number) },
+      '{ a: ReadonlyArray<number> }', 
       {},
       ['Invalid value undefined supplied to : { a: ReadonlyArray<number> }/a: ReadonlyArray<number>']
     ],
     [
       { a: t.tuple([t.string, t.string]) },
+      '{ a: [string, string] }', 
       { a: [1, 2] },
       [
         'Invalid value 1 supplied to : { a: [string, string] }/a: [string, string]/0: string',
@@ -171,11 +201,13 @@ describe('type', () => {
     ],
     [
       { a: t.tuple([t.string, t.string]) },
+      '{ a: [string, string] }', 
       {},
       ['Invalid value undefined supplied to : { a: [string, string] }/a: [string, string]']
     ],
     [
       { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
+      '{ a: (string | number), b: (string | number) }', 
       { a: [1], b: ['b'] },
       [
         'Invalid value [1] supplied to : { a: (string | number), b: (string | number) }/a: (string | number)/0: string',
@@ -186,6 +218,7 @@ describe('type', () => {
     ],
     [
       { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
+      '{ a: (string | number), b: (string | number) }', 
       {},
       [
         'Invalid value undefined supplied to : { a: (string | number), b: (string | number) }/a: (string | number)',
@@ -194,6 +227,7 @@ describe('type', () => {
     ],
     [
       { a: t.intersection([t.number, t.Int]) },
+      '{ a: (number & Int) }', 
       { a: 'a' },
       [
         'Invalid value "a" supplied to : { a: (number & Int) }/a: (number & Int)/0: number',
@@ -202,31 +236,37 @@ describe('type', () => {
     ],
     [
       { a: t.intersection([t.number, t.Int]) },
+      '{ a: (number & Int) }', 
       {},
       ['Invalid value undefined supplied to : { a: (number & Int) }/a: (number & Int)']
     ],
     [
       { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
+      '{ a: Positive }', 
       { a: 'a' },
       ['Invalid value "a" supplied to : { a: Positive }/a: Positive']
     ],
     [
       { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
+      '{ a: Positive }', 
       {},
       ['Invalid value undefined supplied to : { a: Positive }/a: Positive']
     ],
     [
       { a: t.keyof({ foo: null, bar: null }) },
+      '{ a: "foo" | "bar" }', 
       { a: 'baz' },
       ['Invalid value "baz" supplied to : { a: "foo" | "bar" }/a: "foo" | "bar"']
     ],
     [
       { a: t.keyof({ foo: null, bar: null }) },
+      '{ a: "foo" | "bar" }', 
       {},
       ['Invalid value undefined supplied to : { a: "foo" | "bar" }/a: "foo" | "bar"']
     ],
     [
       { a: t.exact(t.type({ x: t.number, y: t.number })) },
+      '{ a: {| x: number, y: number |} }', 
       { a: { x: 1, z: 3 } },
       [
         'Invalid value undefined supplied to : ' +
@@ -235,11 +275,13 @@ describe('type', () => {
     ],
     [
       { a: t.exact(t.type({ x: t.number, y: t.number })) },
+      '{ a: {| x: number, y: number |} }', 
       {},
       ['Invalid value undefined supplied to : ' + '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}']
     ],
     [
       { a: t.strict({ x: t.number, y: t.number }) },
+      '{ a: {| x: number, y: number |} }', 
       { a: { x: 1, z: 3 } },
       [
         'Invalid value undefined supplied to : ' +
@@ -248,21 +290,22 @@ describe('type', () => {
     ],
     [
       { a: t.strict({ x: t.number, y: t.number }) },
+      '{ a: {| x: number, y: number |} }', 
       {},
       ['Invalid value undefined supplied to : ' + '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}']
     ]
   ]
 
   describe('`is` should return `false` for', () => {
-    test.each(failureCases)('props %j given invalid input %j', (props, value) => {
-      const T = t.type(props)
+    test.each(failureCases)('props: %p, name: %p, value: %j', (props, name, value) => {
+      const T = t.type(props, name)
       assert.strictEqual(T.is(value), false)
     })
   })
 
-  describe('`decode` should fail decoding', () => {
-    test.each(failureCases)('with props %j and value %j', (props, value, messages) => {
-      const T = t.type(props)
+  describe('`decode` should fail decoding with', () => {
+    test.each(failureCases)('props: %p, name: %p, value: %j', (props, name, value, messages) => {
+      const T = t.type(props, name)
       assertFailure(T, value, messages)
     })
   })

--- a/test/type.ts
+++ b/test/type.ts
@@ -44,8 +44,8 @@ describe('type', () => {
     [{ a: t.literal('YES') }, '{ a: "YES" }', { a: 'YES' }],
     [{ a: t.partial({ b: t.string, c: t.string }) }, '{ a: Partial<{ b: string, c:string }> }', { a: {} }],
     [
-      { a: t.partial({ b: t.string, c: t.string }) }, 
-      '{ a: Partial<{ b: string, c: string }> }', 
+      { a: t.partial({ b: t.string, c: t.string }) },
+      '{ a: Partial<{ b: string, c: string }> }',
       { a: { b: 'b', c: undefined } }
     ],
     [{ a: t.readonly(t.number) }, '{ a: Readonly<number> }', { a: 1 }],
@@ -60,18 +60,16 @@ describe('type', () => {
     [{ a: t.intersection([t.number, t.Int]) }, '{ a: (number & Int) }', { a: 1 }],
     [
       { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
-      '{ a: Positive }', 
+      '{ a: Positive }',
       { a: 1 }
     ],
     [{ a: t.keyof({ foo: null, bar: null }) }, '{ a: "foo" | "bar" }', { a: 'foo' }],
     [
-      { a: t.exact(t.type({ x: t.number, y: t.number })) }, 
-      '{ a: {| x: number, y: number |} }', 
-      { a: { x: 1, y: 2, z: 3 } }],
-    [
-      { a: t.strict({ x: t.number, y: t.number }) }, 
-      '{ a: {| x: number, y: number |} }', 
-      { a: { x: 1, y: 2, z: 3 } }]
+      { a: t.exact(t.type({ x: t.number, y: t.number })) },
+      '{ a: {| x: number, y: number |} }',
+      { a: { x: 1, y: 2, z: 3 } }
+    ],
+    [{ a: t.strict({ x: t.number, y: t.number }) }, '{ a: {| x: number, y: number |} }', { a: { x: 1, y: 2, z: 3 } }]
   ]
 
   describe('`is` should return `true` for', () => {
@@ -109,33 +107,63 @@ describe('type', () => {
     [{ a: t.bigint }, undefined, {}, ['Invalid value undefined supplied to : { a: bigint }/a: bigint']],
     [{ a: t.boolean }, undefined, { a: 1 }, ['Invalid value 1 supplied to : { a: boolean }/a: boolean']],
     [{ a: t.boolean }, undefined, {}, ['Invalid value undefined supplied to : { a: boolean }/a: boolean']],
-    [{ a: t.UnknownArray }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: UnknownArray }/a: UnknownArray']],
-    [{ a: t.UnknownArray }, undefined, {}, ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']],
     [
       { a: t.UnknownArray },
-      undefined, 
+      undefined,
+      { a: 'a' },
+      ['Invalid value "a" supplied to : { a: UnknownArray }/a: UnknownArray']
+    ],
+    [
+      { a: t.UnknownArray },
+      undefined,
+      {},
+      ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']
+    ],
+    [
+      { a: t.UnknownArray },
+      undefined,
       { a: undefined },
       ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']
     ],
-    [{ a: t.array(t.number) }, '{ a: Array<number> }', { a: 1 }, ['Invalid value 1 supplied to : { a: Array<number> }/a: Array<number>']],
-    [{ a: t.array(t.number) }, '{ a: Array<number> }', {}, ['Invalid value undefined supplied to : { a: Array<number> }/a: Array<number>']],
-    [{ a: t.UnknownRecord }, undefined, { a: [1] }, ['Invalid value [1] supplied to : { a: UnknownRecord }/a: UnknownRecord']],
-    [{ a: t.UnknownRecord }, undefined, {}, ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']],
+    [
+      { a: t.array(t.number) },
+      '{ a: Array<number> }',
+      { a: 1 },
+      ['Invalid value 1 supplied to : { a: Array<number> }/a: Array<number>']
+    ],
+    [
+      { a: t.array(t.number) },
+      '{ a: Array<number> }',
+      {},
+      ['Invalid value undefined supplied to : { a: Array<number> }/a: Array<number>']
+    ],
     [
       { a: t.UnknownRecord },
-      undefined, 
+      undefined,
+      { a: [1] },
+      ['Invalid value [1] supplied to : { a: UnknownRecord }/a: UnknownRecord']
+    ],
+    [
+      { a: t.UnknownRecord },
+      undefined,
+      {},
+      ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']
+    ],
+    [
+      { a: t.UnknownRecord },
+      undefined,
       { a: undefined },
       ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']
     ],
     [
       { a: t.record(t.string, t.string) },
-      '{ a: { [K in string]: string } }', 
+      '{ a: { [K in string]: string } }',
       { a: 1 },
       ['Invalid value 1 supplied to : { a: { [K in string]: string } }/a: { [K in string]: string }']
     ],
     [
       { a: t.record(t.string, t.string) },
-      '{ a: { [K in string]: string } }', 
+      '{ a: { [K in string]: string } }',
       {},
       ['Invalid value undefined supplied to : { a: { [K in string]: string } }/a: { [K in string]: string }']
     ],
@@ -145,7 +173,7 @@ describe('type', () => {
     [{ a: t.literal('YES') }, '{ a: "YES" }', {}, ['Invalid value undefined supplied to : { a: "YES" }/a: "YES"']],
     [
       { a: t.partial({ b: t.string, c: t.string }) },
-      '{ a: Partial<{ b: string, c: string }> }', 
+      '{ a: Partial<{ b: string, c: string }> }',
       { a: { b: 1 } },
       [
         'Invalid value 1 supplied to : ' +
@@ -154,7 +182,7 @@ describe('type', () => {
     ],
     [
       { a: t.partial({ b: t.string, c: t.string }) },
-      '{ a: Partial<{ b: string, c: string }> }', 
+      '{ a: Partial<{ b: string, c: string }> }',
       {},
       [
         'Invalid value undefined supplied to : ' +
@@ -163,31 +191,31 @@ describe('type', () => {
     ],
     [
       { a: t.readonly(t.number) },
-      '{ a: Readonly<number> }', 
+      '{ a: Readonly<number> }',
       { a: 'a' },
       ['Invalid value "a" supplied to : { a: Readonly<number> }/a: Readonly<number>']
     ],
     [
       { a: t.readonly(t.number) },
-      '{ a: Readonly<number> }', 
+      '{ a: Readonly<number> }',
       {},
       ['Invalid value undefined supplied to : { a: Readonly<number> }/a: Readonly<number>']
     ],
     [
       { a: t.readonlyArray(t.number) },
-      '{ a: ReadonlyArray<number> }', 
+      '{ a: ReadonlyArray<number> }',
       { a: 1 },
       ['Invalid value 1 supplied to : { a: ReadonlyArray<number> }/a: ReadonlyArray<number>']
     ],
     [
       { a: t.readonlyArray(t.number) },
-      '{ a: ReadonlyArray<number> }', 
+      '{ a: ReadonlyArray<number> }',
       {},
       ['Invalid value undefined supplied to : { a: ReadonlyArray<number> }/a: ReadonlyArray<number>']
     ],
     [
       { a: t.tuple([t.string, t.string]) },
-      '{ a: [string, string] }', 
+      '{ a: [string, string] }',
       { a: [1, 2] },
       [
         'Invalid value 1 supplied to : { a: [string, string] }/a: [string, string]/0: string',
@@ -196,13 +224,13 @@ describe('type', () => {
     ],
     [
       { a: t.tuple([t.string, t.string]) },
-      '{ a: [string, string] }', 
+      '{ a: [string, string] }',
       {},
       ['Invalid value undefined supplied to : { a: [string, string] }/a: [string, string]']
     ],
     [
       { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
-      '{ a: (string | number), b: (string | number) }', 
+      '{ a: (string | number), b: (string | number) }',
       { a: [1], b: ['b'] },
       [
         'Invalid value [1] supplied to : { a: (string | number), b: (string | number) }/a: (string | number)/0: string',
@@ -213,7 +241,7 @@ describe('type', () => {
     ],
     [
       { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
-      '{ a: (string | number), b: (string | number) }', 
+      '{ a: (string | number), b: (string | number) }',
       {},
       [
         'Invalid value undefined supplied to : { a: (string | number), b: (string | number) }/a: (string | number)',
@@ -222,7 +250,7 @@ describe('type', () => {
     ],
     [
       { a: t.intersection([t.number, t.Int]) },
-      '{ a: (number & Int) }', 
+      '{ a: (number & Int) }',
       { a: 'a' },
       [
         'Invalid value "a" supplied to : { a: (number & Int) }/a: (number & Int)/0: number',
@@ -231,37 +259,37 @@ describe('type', () => {
     ],
     [
       { a: t.intersection([t.number, t.Int]) },
-      '{ a: (number & Int) }', 
+      '{ a: (number & Int) }',
       {},
       ['Invalid value undefined supplied to : { a: (number & Int) }/a: (number & Int)']
     ],
     [
       { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
-      '{ a: Positive }', 
+      '{ a: Positive }',
       { a: 'a' },
       ['Invalid value "a" supplied to : { a: Positive }/a: Positive']
     ],
     [
       { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
-      '{ a: Positive }', 
+      '{ a: Positive }',
       {},
       ['Invalid value undefined supplied to : { a: Positive }/a: Positive']
     ],
     [
       { a: t.keyof({ foo: null, bar: null }) },
-      '{ a: "foo" | "bar" }', 
+      '{ a: "foo" | "bar" }',
       { a: 'baz' },
       ['Invalid value "baz" supplied to : { a: "foo" | "bar" }/a: "foo" | "bar"']
     ],
     [
       { a: t.keyof({ foo: null, bar: null }) },
-      '{ a: "foo" | "bar" }', 
+      '{ a: "foo" | "bar" }',
       {},
       ['Invalid value undefined supplied to : { a: "foo" | "bar" }/a: "foo" | "bar"']
     ],
     [
       { a: t.exact(t.type({ x: t.number, y: t.number })) },
-      '{ a: {| x: number, y: number |} }', 
+      '{ a: {| x: number, y: number |} }',
       { a: { x: 1, z: 3 } },
       [
         'Invalid value undefined supplied to : ' +
@@ -270,7 +298,7 @@ describe('type', () => {
     ],
     [
       { a: t.strict({ x: t.number, y: t.number }) },
-      '{ a: {| x: number, y: number |} }', 
+      '{ a: {| x: number, y: number |} }',
       {},
       ['Invalid value undefined supplied to : ' + '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}']
     ]

--- a/test/type.ts
+++ b/test/type.ts
@@ -92,15 +92,10 @@ describe('type', () => {
     // [ props, name, value, messages ]
     [{ a: t.null }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
     [{ a: t.null }, undefined, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
-    [{ a: t.null }, undefined, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
-    [{ a: t.nullType }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
-    [{ a: t.nullType }, undefined, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
     [{ a: t.nullType }, undefined, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
     [{ a: t.undefined }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: undefined }/a: undefined']],
     [{ a: t.undefined }, undefined, {}, ['Invalid value undefined supplied to : { a: undefined }/a: undefined']],
     [{ a: t.void }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
-    [{ a: t.void }, undefined, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
-    [{ a: t.voidType }, undefined, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
     [{ a: t.voidType }, undefined, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
     [{ a: t.unknown }, undefined, {}, ['Invalid value undefined supplied to : { a: unknown }/a: unknown']],
     [{ a: t.string }, undefined, 1, ['Invalid value 1 supplied to : { a: string }']],
@@ -266,21 +261,6 @@ describe('type', () => {
     ],
     [
       { a: t.exact(t.type({ x: t.number, y: t.number })) },
-      '{ a: {| x: number, y: number |} }', 
-      { a: { x: 1, z: 3 } },
-      [
-        'Invalid value undefined supplied to : ' +
-          '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}/y: number'
-      ]
-    ],
-    [
-      { a: t.exact(t.type({ x: t.number, y: t.number })) },
-      '{ a: {| x: number, y: number |} }', 
-      {},
-      ['Invalid value undefined supplied to : ' + '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}']
-    ],
-    [
-      { a: t.strict({ x: t.number, y: t.number }) },
       '{ a: {| x: number, y: number |} }', 
       { a: { x: 1, z: 3 } },
       [

--- a/test/type.ts
+++ b/test/type.ts
@@ -17,23 +17,280 @@ describe('type', () => {
     })
   })
 
+  const successCases = [
+    // [ props, value ]
+    [{ a: t.null }, { a: null }],
+    [{ a: t.nullType }, { a: null }],
+    [{ a: t.undefined }, { a: undefined }],
+    [{ a: t.void }, { a: undefined }],
+    [{ a: t.voidType }, { a: undefined }],
+    [{ a: t.unknown }, { a: 'a' }],
+    [{ a: t.unknown }, { a: undefined }],
+    [{ a: t.string }, { a: 'a' }],
+    [{ a: t.number }, { a: Number.MAX_VALUE }],
+    [{ a: t.bigint }, { a: BigInt(Number.MAX_VALUE + 1), toJSON: () => `a: BigInt(Number.MAX_VALUE +1)` }],
+    [{ a: t.boolean }, { a: true }],
+    [{ a: t.UnknownArray }, { a: [[1], [2]] }],
+    [{ a: t.UnknownArray }, { a: [] }],
+    [{ a: t.UnknownArray }, { a: [undefined] }],
+    [{ a: t.UnknownArray }, { a: [[undefined], [2]] }],
+    [{ a: t.array(t.number) }, { a: [1, 2] }],
+    [{ a: t.UnknownRecord }, { a: { b: 'b' } }],
+    [{ a: t.UnknownRecord }, { a: {} }],
+    [{ a: t.UnknownRecord }, { a: { undefined } }],
+    [{ a: t.UnknownRecord }, { a: { b: undefined } }],
+    [{ a: t.record(t.string, t.string) }, { a: { b: 'b' } }],
+    [{ a: t.Int }, { a: -1 }],
+    [{ a: t.literal('YES') }, { a: 'YES' }],
+    [{ a: t.partial({ b: t.string, c: t.string }) }, { a: {} }],
+    [{ a: t.partial({ b: t.string, c: t.string }) }, { a: { b: undefined, c: undefined } }],
+    [{ a: t.readonly(t.number) }, { a: 1 }],
+    [{ a: t.readonlyArray(t.number) }, { a: [1, 2] }],
+    [{ a: t.type({ b: t.string, c: t.string }) }, { a: { b: 'b', c: 'c' } }],
+    [{ a: t.tuple([t.string, t.string]) }, { a: ['A', 'B'] }],
+    [
+      { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
+      { a: 1, b: 'b' }
+    ],
+    [{ a: t.intersection([t.number, t.Int]) }, { a: 1 }],
+    [
+      { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
+      { a: 1 }
+    ],
+    [{ a: t.keyof({ foo: null, bar: null }) }, { a: 'foo' }],
+    [{ a: t.exact(t.type({ x: t.number, y: t.number })) }, { a: { x: 1, y: 2, z: 3 } }],
+    [{ a: t.strict({ x: t.number, y: t.number }) }, { a: { x: 1, y: 2, z: 3 } }]
+  ]
+
+  describe('`is` should return `true` for', () => {
+    test.each(successCases)(`props %j given valid input %j`, (props, value) => {
+      const T = t.type(props)
+      assert.strictEqual(T.is(value), true)
+    })
+  })
+
+  const failureCases = [
+    // [ props, value, messages ]
+    [{ a: t.null }, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
+    [{ a: t.null }, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.null }, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.nullType }, { a: 'a' }, ['Invalid value "a" supplied to : { a: null }/a: null']],
+    [{ a: t.nullType }, {}, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.nullType }, { a: undefined }, ['Invalid value undefined supplied to : { a: null }/a: null']],
+    [{ a: t.undefined }, { a: 'a' }, ['Invalid value "a" supplied to : { a: undefined }/a: undefined']],
+    [{ a: t.undefined }, {}, ['Invalid value undefined supplied to : { a: undefined }/a: undefined']],
+    [{ a: t.void }, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
+    [{ a: t.void }, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
+    [{ a: t.voidType }, { a: 'a' }, ['Invalid value "a" supplied to : { a: void }/a: void']],
+    [{ a: t.voidType }, {}, ['Invalid value undefined supplied to : { a: void }/a: void']],
+    [{ a: t.unknown }, {}, ['Invalid value undefined supplied to : { a: unknown }/a: unknown']],
+    [{ a: t.string }, 1, ['Invalid value 1 supplied to : { a: string }']],
+    [{ a: t.string }, {}, ['Invalid value undefined supplied to : { a: string }/a: string']],
+    [{ a: t.string }, { a: undefined }, ['Invalid value undefined supplied to : { a: string }/a: string']],
+    [{ a: t.string }, { a: 1 }, ['Invalid value 1 supplied to : { a: string }/a: string']],
+    [{ a: t.string }, [], ['Invalid value [] supplied to : { a: string }']], // #407
+    [{ a: t.number }, { a: 'a' }, ['Invalid value "a" supplied to : { a: number }/a: number']],
+    [{ a: t.number }, {}, ['Invalid value undefined supplied to : { a: number }/a: number']],
+    [{ a: t.bigint }, { a: 'a' }, ['Invalid value "a" supplied to : { a: bigint }/a: bigint']],
+    [{ a: t.bigint }, {}, ['Invalid value undefined supplied to : { a: bigint }/a: bigint']],
+    [{ a: t.boolean }, { a: 1 }, ['Invalid value 1 supplied to : { a: boolean }/a: boolean']],
+    [{ a: t.boolean }, {}, ['Invalid value undefined supplied to : { a: boolean }/a: boolean']],
+    [{ a: t.UnknownArray }, { a: 'a' }, ['Invalid value "a" supplied to : { a: UnknownArray }/a: UnknownArray']],
+    [{ a: t.UnknownArray }, {}, ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']],
+    [
+      { a: t.UnknownArray },
+      { a: undefined },
+      ['Invalid value undefined supplied to : { a: UnknownArray }/a: UnknownArray']
+    ],
+    [{ a: t.array(t.number) }, { a: 1 }, ['Invalid value 1 supplied to : { a: Array<number> }/a: Array<number>']],
+    [{ a: t.array(t.number) }, {}, ['Invalid value undefined supplied to : { a: Array<number> }/a: Array<number>']],
+    [{ a: t.UnknownRecord }, { a: [1] }, ['Invalid value [1] supplied to : { a: UnknownRecord }/a: UnknownRecord']],
+    [{ a: t.UnknownRecord }, {}, ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']],
+    [
+      { a: t.UnknownRecord },
+      { a: undefined },
+      ['Invalid value undefined supplied to : { a: UnknownRecord }/a: UnknownRecord']
+    ],
+    [
+      { a: t.record(t.string, t.string) },
+      { a: 1 },
+      ['Invalid value 1 supplied to : { a: { [K in string]: string } }/a: { [K in string]: string }']
+    ],
+    [
+      { a: t.record(t.string, t.string) },
+      {},
+      ['Invalid value undefined supplied to : { a: { [K in string]: string } }/a: { [K in string]: string }']
+    ],
+    [{ a: t.Int }, { a: -1.1 }, ['Invalid value -1.1 supplied to : { a: Int }/a: Int']],
+    [{ a: t.Int }, {}, ['Invalid value undefined supplied to : { a: Int }/a: Int']],
+    [{ a: t.literal('YES') }, { a: 'NO' }, ['Invalid value "NO" supplied to : { a: "YES" }/a: "YES"']],
+    [{ a: t.literal('YES') }, {}, ['Invalid value undefined supplied to : { a: "YES" }/a: "YES"']],
+    [
+      { a: t.partial({ b: t.string, c: t.string }) },
+      { a: { b: 1 } },
+      [
+        'Invalid value 1 supplied to : ' +
+          '{ a: Partial<{ b: string, c: string }> }/a: Partial<{ b: string, c: string }>/b: string'
+      ]
+    ],
+    [
+      { a: t.partial({ b: t.string, c: t.string }) },
+      {},
+      [
+        'Invalid value undefined supplied to : ' +
+          '{ a: Partial<{ b: string, c: string }> }/a: Partial<{ b: string, c: string }>'
+      ]
+    ],
+    [
+      { a: t.readonly(t.number) },
+      { a: 'a' },
+      ['Invalid value "a" supplied to : { a: Readonly<number> }/a: Readonly<number>']
+    ],
+    [
+      { a: t.readonly(t.number) },
+      {},
+      ['Invalid value undefined supplied to : { a: Readonly<number> }/a: Readonly<number>']
+    ],
+    [
+      { a: t.readonlyArray(t.number) },
+      { a: 1 },
+      ['Invalid value 1 supplied to : { a: ReadonlyArray<number> }/a: ReadonlyArray<number>']
+    ],
+    [
+      { a: t.readonlyArray(t.number) },
+      {},
+      ['Invalid value undefined supplied to : { a: ReadonlyArray<number> }/a: ReadonlyArray<number>']
+    ],
+    [
+      { a: t.tuple([t.string, t.string]) },
+      { a: [1, 2] },
+      [
+        'Invalid value 1 supplied to : { a: [string, string] }/a: [string, string]/0: string',
+        'Invalid value 2 supplied to : { a: [string, string] }/a: [string, string]/1: string'
+      ]
+    ],
+    [
+      { a: t.tuple([t.string, t.string]) },
+      {},
+      ['Invalid value undefined supplied to : { a: [string, string] }/a: [string, string]']
+    ],
+    [
+      { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
+      { a: [1], b: ['b'] },
+      [
+        'Invalid value [1] supplied to : { a: (string | number), b: (string | number) }/a: (string | number)/0: string',
+        'Invalid value [1] supplied to : { a: (string | number), b: (string | number) }/a: (string | number)/1: number',
+        'Invalid value ["b"] supplied to : { a: (string | number), b: (string | number) }/b: (string | number)/0: string',
+        'Invalid value ["b"] supplied to : { a: (string | number), b: (string | number) }/b: (string | number)/1: number'
+      ]
+    ],
+    [
+      { a: t.union([t.string, t.number]), b: t.union([t.string, t.number]) },
+      {},
+      [
+        'Invalid value undefined supplied to : { a: (string | number), b: (string | number) }/a: (string | number)',
+        'Invalid value undefined supplied to : { a: (string | number), b: (string | number) }/b: (string | number)'
+      ]
+    ],
+    [
+      { a: t.intersection([t.number, t.Int]) },
+      { a: 'a' },
+      [
+        'Invalid value "a" supplied to : { a: (number & Int) }/a: (number & Int)/0: number',
+        'Invalid value "a" supplied to : { a: (number & Int) }/a: (number & Int)/1: Int'
+      ]
+    ],
+    [
+      { a: t.intersection([t.number, t.Int]) },
+      {},
+      ['Invalid value undefined supplied to : { a: (number & Int) }/a: (number & Int)']
+    ],
+    [
+      { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
+      { a: 'a' },
+      ['Invalid value "a" supplied to : { a: Positive }/a: Positive']
+    ],
+    [
+      { a: t.brand(t.number, (n): n is t.Branded<number, { readonly Positive: unique symbol }> => n >= 0, 'Positive') },
+      {},
+      ['Invalid value undefined supplied to : { a: Positive }/a: Positive']
+    ],
+    [
+      { a: t.keyof({ foo: null, bar: null }) },
+      { a: 'baz' },
+      ['Invalid value "baz" supplied to : { a: "foo" | "bar" }/a: "foo" | "bar"']
+    ],
+    [
+      { a: t.keyof({ foo: null, bar: null }) },
+      {},
+      ['Invalid value undefined supplied to : { a: "foo" | "bar" }/a: "foo" | "bar"']
+    ],
+    [
+      { a: t.exact(t.type({ x: t.number, y: t.number })) },
+      { a: { x: 1, z: 3 } },
+      [
+        'Invalid value undefined supplied to : ' +
+          '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}/y: number'
+      ]
+    ],
+    [
+      { a: t.exact(t.type({ x: t.number, y: t.number })) },
+      {},
+      ['Invalid value undefined supplied to : ' + '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}']
+    ],
+    [
+      { a: t.strict({ x: t.number, y: t.number }) },
+      { a: { x: 1, z: 3 } },
+      [
+        'Invalid value undefined supplied to : ' +
+          '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}/y: number'
+      ]
+    ],
+    [
+      { a: t.strict({ x: t.number, y: t.number }) },
+      {},
+      ['Invalid value undefined supplied to : ' + '{ a: {| x: number, y: number |} }/a: {| x: number, y: number |}']
+    ]
+  ]
+
+  describe('`is` should return `false` for', () => {
+    test.each(failureCases)('props %j given invalid input %j', (props, value) => {
+      const T = t.type(props)
+      assert.strictEqual(T.is(value), false)
+    })
+  })
+
+  describe('`decode` should fail decoding', () => {
+    test.each(failureCases)('with props %j and value %j', (props, value, messages) => {
+      const T = t.type(props)
+      assertFailure(T, value, messages)
+    })
+  })
+
   describe('is', () => {
-    it('should return `true` on valid inputs', () => {
-      const T = t.type({ a: t.string })
-      assert.strictEqual(T.is({ a: 'a' }), true)
-    })
-
-    it('should return `false` on invalid inputs', () => {
-      const T = t.type({ a: t.string })
-      assert.strictEqual(T.is({}), false)
-      assert.strictEqual(T.is({ a: 1 }), false)
-      // #407
-      assert.strictEqual(T.is([]), false)
-    })
-
     it('should allow additional properties', () => {
       const T = t.type({ a: t.string })
       assert.strictEqual(T.is({ a: 'a', b: 1 }), true)
+    })
+
+    it('should handle recursive types properly', () => {
+      interface Tree {
+        name: string
+        children?: Array<Tree> | undefined
+      }
+
+      const Tree: t.Type<Tree> = t.recursion('Tree', () =>
+        t.intersection([t.type({ name: t.string }), t.partial({ children: t.union([t.array(Tree), t.undefined]) })])
+      )
+
+      const subtree: Tree = { name: 'subtree', children: [] }
+      const childlessSubtree: Tree = { name: 'childless' }
+      const invalidSubtree = { name: 'invalid', children: 'children ' }
+
+      assert.strictEqual(Tree.is({ name: 'a', children: [subtree] }), true)
+      assert.strictEqual(Tree.is({ name: 'b', children: [childlessSubtree] }), true)
+      assert.strictEqual(Tree.is({ name: 'c' }), true)
+      assert.strictEqual(Tree.is({ name: 'd', children: [invalidSubtree] }), false)
     })
 
     it('#423', () => {
@@ -61,27 +318,19 @@ describe('type', () => {
       assertSuccess(T.decode({ a: '1' }), { a: 1 })
     })
 
-    it('should decode undefined properties as always present keys', () => {
+    it('should decode undefined properties', () => {
       const T1 = t.type({ a: t.undefined })
       assertSuccess(T1.decode({ a: undefined }), { a: undefined })
-      assertSuccess(T1.decode({}), { a: undefined })
 
       const T2 = t.type({ a: t.union([t.number, t.undefined]) })
       assertSuccess(T2.decode({ a: undefined }), { a: undefined })
       assertSuccess(T2.decode({ a: 1 }), { a: 1 })
-      assertSuccess(T2.decode({}), { a: undefined })
 
       const T3 = t.type({ a: t.unknown })
-      assertSuccess(T3.decode({}), { a: undefined })
-    })
+      assertSuccess(T3.decode({ a: undefined }), { a: undefined })
 
-    it('should fail decoding an invalid value', () => {
-      const T = t.type({ a: t.string })
-      assertFailure(T, 1, ['Invalid value 1 supplied to : { a: string }'])
-      assertFailure(T, {}, ['Invalid value undefined supplied to : { a: string }/a: string'])
-      assertFailure(T, { a: 1 }, ['Invalid value 1 supplied to : { a: string }/a: string'])
-      // #407
-      assertFailure(T, [], ['Invalid value [] supplied to : { a: string }'])
+      const T4 = t.type({ a: t.void })
+      assertSuccess(T4.decode({ a: undefined }), { a: undefined })
     })
 
     it('should support the alias `interface`', () => {


### PR DESCRIPTION
Resolves #434 

Changes the handling of missing properties in `t.type` interface types to align with TypeScript.

Adds many additional tests (~170) to confirm that everything behaves as expected.  Also changes a small number of pre-existing tests that asserted the old behavior.

Note that people who rely on the old behavior may see this fix as a breaking change.
