### PR TITLE
docs: fix Codec.md

### DIFF
--- a/Codec.md
+++ b/Codec.md
@@ -38,7 +38,7 @@ const decoder: D.Decoder<unknown, number> = pipe(
   })
 )
 
-const encoder: E.Encoder<string, unknown> = {
+const encoder: E.Encoder<string, number> = {
   encode: String
 }
 


### PR DESCRIPTION
An `"error TS2322: Type 'Codec<unknown, string, unknown>' is not assignable to type 'Codec<unknown, string, number>'.
  Type 'unknown' is not assignable to type 'number'"` error occurs when using the example source code of the [`Codec.md`](https://github.com/gcanti/io-ts/blob/master/Codec.md) file.

So I fix `encoder` type from `E.Encoder<string, unknown>` to `E.Encoder<string, number>`