### PR TITLE
add defined value codec

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -122,11 +122,15 @@ Added in v1.0.0
   - [Brand (interface)](#brand-interface)
   - [BrandC (interface)](#brandc-interface)
   - [Branded (type alias)](#branded-type-alias)
-  - [DictionaryType (class)](#dictionarytype-class)
+  - [Defined (type alias)](#defined-type-alias)
+  - [DefinedC (interface)](#definedc-interface)
+  - [DefinedType (class)](#definedtype-class)
     - [\_tag (property)](#_tag-property-10)
+  - [DictionaryType (class)](#dictionarytype-class)
+    - [\_tag (property)](#_tag-property-11)
   - [ExactC (interface)](#exactc-interface)
   - [ExactType (class)](#exacttype-class)
-    - [\_tag (property)](#_tag-property-11)
+    - [\_tag (property)](#_tag-property-12)
   - [HasProps (type alias)](#hasprops-type-alias)
   - [HasPropsIntersection (interface)](#haspropsintersection-interface)
   - [HasPropsReadonly (interface)](#haspropsreadonly-interface)
@@ -135,49 +139,49 @@ Added in v1.0.0
   - [Int (type alias)](#int-type-alias)
   - [IntBrand (interface)](#intbrand-interface)
   - [InterfaceType (class)](#interfacetype-class)
-    - [\_tag (property)](#_tag-property-12)
+    - [\_tag (property)](#_tag-property-13)
   - [IntersectionC (interface)](#intersectionc-interface)
   - [IntersectionType (class)](#intersectiontype-class)
-    - [\_tag (property)](#_tag-property-13)
+    - [\_tag (property)](#_tag-property-14)
   - [KeyofC (interface)](#keyofc-interface)
   - [KeyofType (class)](#keyoftype-class)
-    - [\_tag (property)](#_tag-property-14)
+    - [\_tag (property)](#_tag-property-15)
   - [LiteralC (interface)](#literalc-interface)
   - [LiteralType (class)](#literaltype-class)
-    - [\_tag (property)](#_tag-property-15)
+    - [\_tag (property)](#_tag-property-16)
   - [Mixed (interface)](#mixed-interface)
   - [NullC (interface)](#nullc-interface)
   - [NullType (class)](#nulltype-class)
-    - [\_tag (property)](#_tag-property-16)
+    - [\_tag (property)](#_tag-property-17)
   - [NumberC (interface)](#numberc-interface)
   - [NumberType (class)](#numbertype-class)
-    - [\_tag (property)](#_tag-property-17)
+    - [\_tag (property)](#_tag-property-18)
   - [OutputOf (type alias)](#outputof-type-alias)
   - [OutputOfDictionary (type alias)](#outputofdictionary-type-alias)
   - [OutputOfPartialProps (type alias)](#outputofpartialprops-type-alias)
   - [OutputOfProps (type alias)](#outputofprops-type-alias)
   - [PartialC (interface)](#partialc-interface)
   - [PartialType (class)](#partialtype-class)
-    - [\_tag (property)](#_tag-property-18)
+    - [\_tag (property)](#_tag-property-19)
   - [Props (interface)](#props-interface)
   - [ReadonlyArrayC (interface)](#readonlyarrayc-interface)
   - [ReadonlyArrayType (class)](#readonlyarraytype-class)
-    - [\_tag (property)](#_tag-property-19)
+    - [\_tag (property)](#_tag-property-20)
   - [ReadonlyC (interface)](#readonlyc-interface)
   - [ReadonlyType (class)](#readonlytype-class)
-    - [\_tag (property)](#_tag-property-20)
+    - [\_tag (property)](#_tag-property-21)
   - [RecordC (interface)](#recordc-interface)
   - [RecursiveType (class)](#recursivetype-class)
-    - [\_tag (property)](#_tag-property-21)
+    - [\_tag (property)](#_tag-property-22)
     - [type (property)](#type-property)
   - [RefinementType (class)](#refinementtype-class)
-    - [\_tag (property)](#_tag-property-22)
+    - [\_tag (property)](#_tag-property-23)
   - [StringC (interface)](#stringc-interface)
   - [StringType (class)](#stringtype-class)
-    - [\_tag (property)](#_tag-property-23)
+    - [\_tag (property)](#_tag-property-24)
   - [TupleC (interface)](#tuplec-interface)
   - [TupleType (class)](#tupletype-class)
-    - [\_tag (property)](#_tag-property-24)
+    - [\_tag (property)](#_tag-property-25)
   - [TypeC (interface)](#typec-interface)
   - [TypeOf (type alias)](#typeof-type-alias)
   - [TypeOfDictionary (type alias)](#typeofdictionary-type-alias)
@@ -185,19 +189,20 @@ Added in v1.0.0
   - [TypeOfProps (type alias)](#typeofprops-type-alias)
   - [UndefinedC (interface)](#undefinedc-interface)
   - [UndefinedType (class)](#undefinedtype-class)
-    - [\_tag (property)](#_tag-property-25)
+    - [\_tag (property)](#_tag-property-26)
   - [UnionC (interface)](#unionc-interface)
   - [UnionType (class)](#uniontype-class)
-    - [\_tag (property)](#_tag-property-26)
+    - [\_tag (property)](#_tag-property-27)
   - [UnknownArrayC (interface)](#unknownarrayc-interface)
   - [UnknownC (interface)](#unknownc-interface)
   - [UnknownRecordC (interface)](#unknownrecordc-interface)
   - [UnknownType (class)](#unknowntype-class)
-    - [\_tag (property)](#_tag-property-27)
+    - [\_tag (property)](#_tag-property-28)
   - [VoidC (interface)](#voidc-interface)
   - [VoidType (class)](#voidtype-class)
-    - [\_tag (property)](#_tag-property-28)
+    - [\_tag (property)](#_tag-property-29)
   - [appendContext](#appendcontext)
+  - [defined](#defined)
   - [exact](#exact)
   - [failure](#failure)
   - [failures](#failures)
@@ -1517,6 +1522,48 @@ export type Branded<A, B> = A & Brand<B>
 
 Added in v1.8.1
 
+## Defined (type alias)
+
+**Signature**
+
+```ts
+export type Defined = {} | null
+```
+
+Added in v2.3.0
+
+## DefinedC (interface)
+
+**Signature**
+
+```ts
+export interface DefinedC extends DefinedType {}
+```
+
+Added in v2.3.0
+
+## DefinedType (class)
+
+**Signature**
+
+```ts
+export declare class DefinedType {
+  constructor()
+}
+```
+
+Added in v2.3.0
+
+### \_tag (property)
+
+**Signature**
+
+```ts
+readonly _tag: "DefinedType"
+```
+
+Added in v2.3.0
+
 ## DictionaryType (class)
 
 **Signature**
@@ -2459,6 +2506,16 @@ export declare const appendContext: (c: Context, key: string, decoder: Decoder<a
 ```
 
 Added in v1.0.0
+
+## defined
+
+**Signature**
+
+```ts
+export declare const defined: DefinedC
+```
+
+Added in v2.3.0
 
 ## exact
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,36 @@ export interface UndefinedC extends UndefinedType {}
 const undefinedType: UndefinedC = new UndefinedType()
 
 /**
+ * @since 2.3.0
+ */
+export type Defined = {} | null
+
+/**
+ * @since 2.3.0
+ */
+export class DefinedType extends Type<Defined> {
+  /**
+   * @since 2.3.0
+   */
+  readonly _tag: 'DefinedType' = 'DefinedType'
+  constructor() {
+    super(
+      'defined',
+      (u): u is Defined => typeof u !== 'undefined',
+      (u, c) => (this.is(u) ? success(u) : failure(u, c)),
+      identity
+    )
+  }
+}
+
+/**
+ * @since 2.3.0
+ */
+export interface DefinedC extends DefinedType {}
+
+const definedType: DefinedC = new DefinedType()
+
+/**
  * @since 1.2.0
  */
 export class VoidType extends Type<void> {
@@ -1865,6 +1895,13 @@ export {
    * @since 1.0.0
    */
   undefinedType as undefined
+}
+
+export {
+  /**
+   * @since 2.3.0
+   */
+  definedType as defined
 }
 
 export {

--- a/test/2.1.x/default-types.ts
+++ b/test/2.1.x/default-types.ts
@@ -77,6 +77,33 @@ describe('undefined', () => {
   })
 })
 
+describe('defined', () => {
+  it('should decode any defined value', () => {
+    assertSuccess(t.defined.decode(null))
+    assertSuccess(t.defined.decode('foo'))
+    assertSuccess(t.defined.decode(1))
+    assertSuccess(t.defined.decode(true))
+    assertSuccess(t.defined.decode({}))
+    assertSuccess(t.defined.decode([]))
+    assertSuccess(t.defined.decode(/a/))
+  })
+
+  it('should accept any defined value', () => {
+    assert.ok(t.defined.is(null))
+    assert.ok(t.defined.is('foo'))
+    assert.ok(t.defined.is(1))
+    assert.ok(t.defined.is(true))
+    assert.ok(t.defined.is({}))
+    assert.ok(t.defined.is([]))
+    assert.ok(t.defined.is(/a/))
+  })
+
+  it('should fail decoding undefined value', () => {
+    const T = t.defined
+    assertFailure(T, undefined, ['Invalid value undefined supplied to : defined'])
+  })
+})
+
 describe('unknown', () => {
   it('should decode any value', () => {
     assertSuccess(t.unknown.decode(null))


### PR DESCRIPTION
This PR adds a codec for defined values, the opposite of `undefined`. It is useful for situations where you have to describe the exact type and assert the existence of the type separately. See #483 