### PR TITLE
Make toForest stack-safe

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -549,10 +549,27 @@ const toTree: (e: DE.DecodeError<string>) => Tree<string> = DE.fold({
   Wrap: (error, errors) => make(error, toForest(errors))
 })
 
-const toForest: (e: DecodeError) => ReadonlyArray<Tree<string>> = FS.fold(
-  (value) => [toTree(value)],
-  (left, right) => toForest(left).concat(toForest(right))
-)
+const toForest = (e: DecodeError): ReadonlyArray<Tree<string>> => {
+  const stack = [];
+  let focus = e;
+  const res = [];
+  while (true) {
+    switch (focus._tag) {
+      case "Of":
+        res.push(toTree(focus.value));
+        if (stack.length === 0) {
+          return res;
+        } else {
+          focus = stack.pop()!;
+        }
+        break;
+      case "Concat":
+        stack.push(focus.right);
+        focus = focus.left;
+        break;
+    }
+  }
+};
 
 /**
  * @since 2.2.7

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -550,26 +550,26 @@ const toTree: (e: DE.DecodeError<string>) => Tree<string> = DE.fold({
 })
 
 const toForest = (e: DecodeError): ReadonlyArray<Tree<string>> => {
-  const stack = [];
-  let focus = e;
-  const res = [];
+  const stack = []
+  let focus = e
+  const res = []
   while (true) {
     switch (focus._tag) {
-      case "Of":
-        res.push(toTree(focus.value));
+      case 'Of':
+        res.push(toTree(focus.value))
         if (stack.length === 0) {
-          return res;
+          return res
         } else {
-          focus = stack.pop()!;
+          focus = stack.pop()!
         }
-        break;
-      case "Concat":
-        stack.push(focus.right);
-        focus = focus.left;
-        break;
+        break
+      case 'Concat':
+        stack.push(focus.right)
+        focus = focus.left
+        break
     }
   }
-};
+}
 
 /**
  * @since 2.2.7

--- a/test/Decoder.ts
+++ b/test/Decoder.ts
@@ -534,6 +534,22 @@ describe('Decoder', () => {
   // -------------------------------------------------------------------------------------
 
   describe('draw', () => {
+    it('is stack safe', () => {
+      expect(() => {
+        E.mapLeft(_.draw)(
+          _.record(_.type({ done: _.boolean })).decode(
+            new Array(10000)
+              .fill({})
+              .map((v, k) => [k, v])
+              .reduce((acc, [k, v]) => {
+                acc[k] = v
+                return acc
+              }, {} as Record<string, unknown>)
+          )
+        )
+      }).not.toThrow()
+    })
+
     it('draw', () => {
       const decoder = _.type({
         a: _.string,

--- a/test/FreeSemigroup.ts
+++ b/test/FreeSemigroup.ts
@@ -1,0 +1,13 @@
+import * as FS from '../src/FreeSemigroup'
+
+describe('FreeSemigroup', () => {
+  it('fold', () => {
+    const sum: (input: FS.FreeSemigroup<string>) => string = FS.fold(
+      (value) => value,
+      (left, right) => sum(left) + sum(right)
+    )
+
+    expect(sum(FS.of('1'))).toBe('1')
+    expect(sum(FS.concat(FS.of('1'), FS.of('2')))).toBe('12')
+  })
+})


### PR DESCRIPTION
Without this change on big input with many errors toForest throws stack overflow.

<img width="349" alt="Screen Shot 2020-10-03 at 8 40 50 PM" src="https://user-images.githubusercontent.com/1932383/94997117-294e8600-05ba-11eb-9b33-74118cc0474c.png">




---


I've added very simple test for FreeSemigroup because of this:
<img width="425" alt="Screen Shot 2020-10-03 at 8 48 44 PM" src="https://user-images.githubusercontent.com/1932383/94997139-57cc6100-05ba-11eb-9e52-e7a289fdeded.png">
