### PR TITLE
Experimental: add `getErrorForest`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dev
 coverage
 declaration/out/src
+/.idea

--- a/Decoder.md
+++ b/Decoder.md
@@ -377,6 +377,38 @@ Note that you can define an `interface` instead of a type alias
 export interface Person extends D.TypeOf<typeof Person> {}
 ```
 
+# Customize errors tree
+
+Errors tree can be got by `getErrorForest` to customize error report
+
+```ts
+ const decoder = _.type({
+    a: _.string
+  })
+ const tree = getErrorForest(decoder.decode({ c: [1] })
+/*
+E.left([
+  {
+    value: {
+      _tag: 'Key',
+      key: 'a',
+      kind: 'required'
+    },
+    forest: [
+      {
+        value: {
+          _tag: 'Leaf',
+          error: 'string',
+           actual: undefined
+        },
+        forest: []
+      }
+    ]
+  }
+])
+*/
+```
+
 # Built-in error reporter
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/DecodeError.ts
+++ b/src/DecodeError.ts
@@ -98,6 +98,18 @@ export interface Wrap<E> {
 export type DecodeError<E> = Leaf<E> | Key<E> | Index<E> | Member<E> | Lazy<E> | Wrap<E>
 
 /**
+ * @category model
+ * @since 2.2.14
+ */
+export type DecodeErrorLeaf<E> =
+  | Leaf<E>
+  | Omit<Key<E>, 'errors'>
+  | Omit<Index<E>, 'errors'>
+  | Omit<Member<E>, 'errors'>
+  | Omit<Lazy<E>, 'errors'>
+  | Omit<Wrap<E>, 'errors'>
+
+/**
  * @category constructors
  * @since 2.2.7
  */

--- a/test/Decoder.ts
+++ b/test/Decoder.ts
@@ -533,6 +533,36 @@ describe('Decoder', () => {
   // utils
   // -------------------------------------------------------------------------------------
 
+  describe('getErrorForest', () => {
+    it('getErrorForest', function () {
+      const decoder = _.type({
+        a: _.string
+      })
+      assert.deepStrictEqual(
+        pipe(decoder.decode({ c: [1] }), E.mapLeft(_.getErrorForest)),
+        E.left([
+          {
+            value: {
+              _tag: 'Key',
+              key: 'a',
+              kind: 'required'
+            },
+            forest: [
+              {
+                value: {
+                  _tag: 'Leaf',
+                  error: 'string',
+                  actual: undefined
+                },
+                forest: []
+              }
+            ]
+          }
+        ])
+      )
+    })
+  })
+
   describe('draw', () => {
     it('is stack safe', () => {
       expect(() => {


### PR DESCRIPTION
Add `getErrorForest` for customize error report.
Errors tree can be got by `getErrorForest` to customize error report

```ts
 const decoder = _.type({
    a: _.string
  })
 const tree = getErrorForest(decoder.decode({ c: [1] })
/*
E.left([
  {
    value: {
      _tag: 'Key',
      key: 'a',
      kind: 'required'
    },
    forest: [
      {
        value: {
          _tag: 'Leaf',
          error: 'string',
           actual: undefined
        },
        forest: []
      }
    ]
  }
])
*/
```