### PR TITLE
Fix.unknown record

### DIFF
--- a/src/Guard.ts
+++ b/src/Guard.ts
@@ -93,7 +93,7 @@ export const UnknownArray: Guard<unknown, Array<unknown>> = {
  * @since 2.2.0
  */
 export const UnknownRecord: Guard<unknown, Record<string, unknown>> = {
-  is: (u: unknown): u is Record<string, unknown> => Object.prototype.toString.call(u) === '[object Object]'
+  is: (u: unknown): u is Record<string, unknown> => u != null && typeof u === 'object' && !Array.isArray(u)
 }
 
 // -------------------------------------------------------------------------------------

--- a/test/Guard.ts
+++ b/test/Guard.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import * as G from '../src/Guard'
 import { pipe } from 'fp-ts/lib/pipeable'
+import { Stream } from 'stream'
 
 interface NonEmptyStringBrand {
   readonly NonEmptyString: unique symbol
@@ -279,6 +280,18 @@ describe('Guard', () => {
       assert.deepStrictEqual(guard.is({ _tag: 1, a: 'a' }), true)
       assert.deepStrictEqual(guard.is({ _tag: 2, b: 1 }), true)
       assert.deepStrictEqual(guard.is({ _tag: 2, b: 'a' }), false)
+    })
+  })
+
+  describe('UnknownRecord', () => {
+    it('should accept valid inputs', () => {
+      assert.strictEqual(G.UnknownRecord.is(new Set()), true)
+      assert.strictEqual(G.UnknownRecord.is(new Map()), true)
+      assert.strictEqual(G.UnknownRecord.is(new Stream()), true)
+    })
+
+    it('should reject invalid inputs', () => {
+      assert.strictEqual(G.UnknownRecord.is([]), false)
     })
   })
 })


### PR DESCRIPTION
I've added some test against the `Stream` object in node, to demonstrate that it'll accept any non-primitive, non-null, non-array object.

closes #559 