### PR TITLE
feat: Add ability for contextual additional constraints

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -22,10 +22,15 @@ Added in v1.0.0
     - [asDecoder (method)](#asdecoder-method)
     - [asEncoder (method)](#asencoder-method)
     - [decode (method)](#decode-method)
+    - [validate (method)](#validate-method)
+    - [validateWith (method)](#validatewith-method)
     - [\_A (property)](#_a-property)
     - [\_O (property)](#_o-property)
     - [\_I (property)](#_i-property)
+    - [\_validators (property)](#_validators-property)
+    - [\_validate (property)](#_validate-property)
   - [TypeOf (type alias)](#typeof-type-alias)
+  - [TypeValidator (type alias)](#typevalidator-type-alias)
 - [Decode error](#decode-error)
   - [Context (interface)](#context-interface)
   - [ContextEntry (interface)](#contextentry-interface)
@@ -272,7 +277,7 @@ export declare class Type<A, O, I> {
     /** a custom type guard */
     readonly is: Is<A>,
     /** succeeds if a value of type I can be decoded to a value of type A */
-    readonly validate: Validate<I, A>,
+    validate: Validate<I, A>,
     /** converts a value of type A to a value of type O */
     readonly encode: Encode<A, O>
   )
@@ -327,6 +332,26 @@ decode(i: I): Validation<A>
 
 Added in v1.0.0
 
+### validate (method)
+
+**Signature**
+
+```ts
+validate(i: I, c: Context): Validation<A>
+```
+
+Added in v2.2.16
+
+### validateWith (method)
+
+**Signature**
+
+```ts
+validateWith(v: TypeValidator<A>): Type<A, O, I>
+```
+
+Added in v2.2.16
+
 ### \_A (property)
 
 **Signature**
@@ -357,6 +382,26 @@ readonly _I: I
 
 Added in v1.0.0
 
+### \_validators (property)
+
+**Signature**
+
+```ts
+_validators: Validate<A, void>[]
+```
+
+Added in v2.2.16
+
+### \_validate (property)
+
+**Signature**
+
+```ts
+readonly _validate: Validate<I, A>
+```
+
+Added in v2.2.16
+
 ## TypeOf (type alias)
 
 **Signature**
@@ -366,6 +411,16 @@ export type TypeOf<C extends Any> = C['_A']
 ```
 
 Added in v1.0.0
+
+## TypeValidator (type alias)
+
+**Signature**
+
+```ts
+export type TypeValidator<A> = Validate<A, void>
+```
+
+Added in v2.2.16
 
 # Decode error
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/2.1.x/validate.ts
+++ b/test/2.1.x/validate.ts
@@ -1,0 +1,135 @@
+import * as t from '../../src/index'
+import { assertFailure, assertSuccess } from './helpers'
+
+describe('validate', () => {
+  describe('type', () => {
+    it('should validate type', () => {
+      const T = t.type({ a: t.string, b: t.number })
+      T.validateWith((v, c) => {
+        if (v.b < 10) {
+          return v.a === 'low' ? t.success(undefined) : t.failure(v, c, 'a must be set to "low"')
+        } else {
+          return v.a === 'high' ? t.success(undefined) : t.failure(v, c, 'a must be set to "high"')
+        }
+      })
+      assertSuccess(T.decode({ a: 'low', b: 5 }), { a: 'low', b: 5 })
+      assertSuccess(T.decode({ a: 'high', b: 12 }), { a: 'high', b: 12 })
+      assertFailure(T, { a: 'high' }, ['Invalid value undefined supplied to : { a: string, b: number }/b: number'])
+      assertFailure(T, { b: 5 }, ['Invalid value undefined supplied to : { a: string, b: number }/a: string'])
+      assertFailure(T, { a: 'low', b: 12 }, ['a must be set to "high"'])
+      assertFailure(T, { a: 'high', b: 5 }, ['a must be set to "low"'])
+    })
+    it('should validate nested types', () => {
+      const T = t.type({ a: t.string, b: t.number })
+      T.validateWith((v, c) => {
+        if (v.b < 10) {
+          return v.a === 'low' ? t.success(undefined) : t.failure(v, c, 'a must be set to "low"')
+        } else {
+          return v.a === 'high' ? t.success(undefined) : t.failure(v, c, 'a must be set to "high"')
+        }
+      })
+      const T1 = t.type({ n: T })
+      assertSuccess(T1.decode({ n: { a: 'low', b: 5 } }), { n: { a: 'low', b: 5 } })
+      assertSuccess(T1.decode({ n: { a: 'high', b: 12 } }), { n: { a: 'high', b: 12 } })
+      assertFailure(T1, { n: { a: 'high' } }, [
+        'Invalid value undefined supplied to : { n: { a: string, b: number } }/n: { a: string, b: number }/b: number'
+      ])
+      assertFailure(T1, { n: { b: 5 } }, [
+        'Invalid value undefined supplied to : { n: { a: string, b: number } }/n: { a: string, b: number }/a: string'
+      ])
+      assertFailure(T1, { n: { a: 'low', b: 12 } }, ['a must be set to "high"'])
+      assertFailure(T1, { n: { a: 'high', b: 5 } }, ['a must be set to "low"'])
+    })
+    it('should validate type with multiple validators', () => {
+      const T = t.type({ a: t.string, b: t.number })
+      T.validateWith((v, c) => {
+        if (v.b < 10) {
+          return v.a === 'low' ? t.success(undefined) : t.failure(v, c, 'a must be set to "low"')
+        }
+        return t.success(undefined)
+      }).validateWith((v, c) => {
+        if (v.b >= 10) {
+          return v.a === 'high' ? t.success(undefined) : t.failure(v, c, 'a must be set to "high"')
+        }
+        return t.success(undefined)
+      })
+      assertSuccess(T.decode({ a: 'low', b: 5 }), { a: 'low', b: 5 })
+      assertSuccess(T.decode({ a: 'high', b: 12 }), { a: 'high', b: 12 })
+      assertFailure(T, { a: 'high' }, ['Invalid value undefined supplied to : { a: string, b: number }/b: number'])
+      assertFailure(T, { b: 5 }, ['Invalid value undefined supplied to : { a: string, b: number }/a: string'])
+      assertFailure(T, { a: 'low', b: 12 }, ['a must be set to "high"'])
+      assertFailure(T, { a: 'high', b: 5 }, ['a must be set to "low"'])
+    })
+    it('should validate type with multiple independent validators', () => {
+      const T = t.type({ a: t.string, b: t.number, c: t.number })
+      T.validateWith((v, c) => {
+        if (v.b < 10) {
+          return v.a === 'low' ? t.success(undefined) : t.failure(v, c, 'a must be set to "low"')
+        } else {
+          return v.a === 'high' ? t.success(undefined) : t.failure(v, c, 'a must be set to "high"')
+        }
+      }).validateWith((v, c) => {
+        return v.c < 20 ? t.success(undefined) : t.failure(v, c, 'c must be lower than 20')
+      })
+      assertFailure(T, { a: 'low', b: 12, c: 5 }, ['a must be set to "high"'])
+      assertFailure(T, { a: 'high', b: 5, c: 5 }, ['a must be set to "low"'])
+      assertFailure(T, { a: 'low', b: 12, c: 21 }, ['a must be set to "high"', 'c must be lower than 20'])
+      assertFailure(T, { a: 'high', b: 5, c: 35 }, ['a must be set to "low"', 'c must be lower than 20'])
+    })
+  })
+  describe('intersection', () => {
+    it('should validate intersection', () => {
+      const T1 = t.type({ a: t.string })
+      const T2 = t.partial({ b: t.number })
+      const T = t.intersection([T1, T2])
+      T.validateWith((v, c) => {
+        if (!v.b) {
+          return t.success(undefined)
+        }
+        if (v.b < 10) {
+          return v.a === 'low' ? t.success(undefined) : t.failure(v, c, 'a must be set to "low"')
+        } else {
+          return v.a === 'high' ? t.success(undefined) : t.failure(v, c, 'a must be set to "high"')
+        }
+      })
+      assertSuccess(T.decode({ a: 'low', b: 5 }), { a: 'low', b: 5 })
+      assertSuccess(T.decode({ a: 'high', b: 12 }), { a: 'high', b: 12 })
+      assertSuccess(T.decode({ a: 'high' }), { a: 'high' })
+      assertFailure(T, { b: 5 }, [
+        'Invalid value undefined supplied to : ({ a: string } & Partial<{ b: number }>)/0: { a: string }/a: string'
+      ])
+      assertFailure(T, { a: 'low', b: 12 }, ['a must be set to "high"'])
+      assertFailure(T, { a: 'high', b: 5 }, ['a must be set to "low"'])
+    })
+    it('should validate intersection with multiple validators', () => {
+      const T1 = t.type({ a: t.string })
+      const T2 = t.partial({ b: t.number })
+      const T = t.intersection([T1, T2])
+      T.validateWith((v, c) => {
+        if (!v.b) {
+          return t.success(undefined)
+        }
+        if (v.b < 10) {
+          return v.a === 'low' ? t.success(undefined) : t.failure(v, c, 'a must be set to "low"')
+        }
+        return t.success(undefined)
+      }).validateWith((v, c) => {
+        if (!v.b) {
+          return t.success(undefined)
+        }
+        if (v.b >= 10) {
+          return v.a === 'high' ? t.success(undefined) : t.failure(v, c, 'a must be set to "high"')
+        }
+        return t.success(undefined)
+      })
+      assertSuccess(T.decode({ a: 'low', b: 5 }), { a: 'low', b: 5 })
+      assertSuccess(T.decode({ a: 'high', b: 12 }), { a: 'high', b: 12 })
+      assertSuccess(T.decode({ a: 'high' }), { a: 'high' })
+      assertFailure(T, { b: 5 }, [
+        'Invalid value undefined supplied to : ({ a: string } & Partial<{ b: number }>)/0: { a: string }/a: string'
+      ])
+      assertFailure(T, { a: 'low', b: 12 }, ['a must be set to "high"'])
+      assertFailure(T, { a: 'high', b: 5 }, ['a must be set to "low"'])
+    })
+  })
+})


### PR DESCRIPTION
Fix #578 

Working example:

```typescript
import * as t from 'io-ts';
import { PathReporter } from 'io-ts/PathReporter'

const unreachable = (arg: never, message = 'unreachable'): never => {
  throw new Error(message)
}

const Title = t.keyof({
  Adult: null,
  Child: null
}, 'Title')

const Person = t.type({
  title: Title,
  age: t.number
}, 'Person')

Person.validateWith((i , c) => {
  if (i.title === 'Child') {
    return i.age < 18 ? t.success(undefined) : t.failure(i, c, 'Child age must be under 18')
  } else if (i.title === 'Adult') {
    return i.age >= 18 ? t.success(undefined) : t.failure(i, c, 'Adult age must be 18 or above')
  } else {
    return unreachable(i.title, 'Invalid title value')
  }
})

console.log(Person.decode({ title: 'Adult', age: 19 })) // { _tag: 'Right', right: { title: 'Adult', age: 19 } }
console.log(Person.decode({ title: 'Child', age: 8 })) // { _tag: 'Right', right: { title: 'Child', age: 8 } }
console.log(PathReporter.report(Person.decode({ title: 'Child', age: 19 }))) // [ 'Child age must be under 18' ]
console.log(PathReporter.report(Person.decode({ title: 'Adult', age: 8 }))) // [ 'Adult age must be 18 or above' ]
console.log(PathReporter.report(Person.decode({ age: 5 }))) // [ 'Invalid value undefined supplied to : Person/title: Title']
```