### PR TITLE
add ExactType to HasProps interface

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1299,6 +1299,7 @@ export type HasProps =
   | HasPropsReadonly
   | HasPropsIntersection
   | InterfaceType<any, any, any, any>
+  | ExactType<any, any, any, any>
   // tslint:disable-next-line: deprecation
   | StrictType<any, any, any, any>
   | PartialType<any, any, any, any>

--- a/src/index.ts
+++ b/src/index.ts
@@ -508,6 +508,7 @@ export type HasProps =
   | HasPropsReadonly
   | HasPropsIntersection
   | InterfaceType<any, any, any, any>
+  | ExactType<any, any, any, any>
   // tslint:disable-next-line: deprecation
   | StrictType<any, any, any, any>
   | PartialType<any, any, any, any>
@@ -516,6 +517,7 @@ function getProps(codec: HasProps): Props {
   switch (codec._tag) {
     case 'RefinementType':
     case 'ReadonlyType':
+    case 'ExactType':
       return getProps(codec.type)
     case 'InterfaceType':
     case 'StrictType':

--- a/test/2.1.x/exact.ts
+++ b/test/2.1.x/exact.ts
@@ -3,6 +3,18 @@ import { assertSuccess, assertFailure, assertStrictEqual, NumberFromString } fro
 import * as assert from 'assert'
 
 describe('exact', () => {
+  describe('HasProps', () => {
+    it('should wok on nested exact types', () => {
+      const T1 = t.type({ a: t.string })
+      const T2 = t.type({ b: t.string })
+      const T12 = t.exact(t.intersection([T1, T2]))
+      const T3 = t.type({ c: t.string })
+      const T = t.exact(t.intersection([T12, T3]))
+      const x = { a: 'a', b: 'b', c: 'c', d: 'd' }
+      assert.deepStrictEqual(T.encode(x), { a: 'a', b: 'b', c: 'c' })
+    })
+  })
+
   describe('name', () => {
     it('should assign a default name', () => {
       const T = t.exact(t.type({ foo: t.string }))


### PR DESCRIPTION
ExactType does have props but is missing from the HasProps interface. When StrictType was deprecated ExactType was not added instead.

The following valid scenario will be fixed with this PR:
```typescript
import * as t from 'io-ts';

const T1 = t.type({ a: t.string });
const T2 = t.type({ b: t.string });
const T12 = t.exact(t.intersection([T1, T2]));
const T3 = t.type({ c: t.string });
const T123 = t.exact(t.intersection([T12, T3]));
/**
 *  Argument of type 'IntersectionC<[ExactC<IntersectionC<[TypeC<{ a: StringC; }>, TypeC<{ b: StringC; }>]>>, TypeC<{ c: StringC; }>]>' is not assignable to parameter of type 'HasProps'.
 *  Type 'IntersectionC<[ExactC<IntersectionC<[TypeC<{ a: StringC; }>, TypeC<{ b: StringC; }>]>>, TypeC<{ c: StringC; }>]>' is not assignable to type 'HasPropsIntersection'.
 *    Types of property 'types' are incompatible.
 *      Type '[ExactC<IntersectionC<[TypeC<{ a: StringC; }>, TypeC<{ b: StringC; }>]>>, TypeC<{ c: StringC; }>]' is not assignable to type 'HasProps[]'.
 *        Type 'ExactC<IntersectionC<[TypeC<{ a: StringC; }>, TypeC<{ b: StringC; }>]>> | TypeC<{ c: StringC; }>' is not assignable to type 'HasProps'.
 *          Type 'ExactC<IntersectionC<[TypeC<{ a: StringC; }>, TypeC<{ b: StringC; }>]>>' is not assignable to type 'HasProps'.
 *            Type 'ExactC<IntersectionC<[TypeC<{ a: StringC; }>, TypeC<{ b: StringC; }>]>>' is not assignable to type 'HasPropsReadonly'.
 *              Types of property '_tag' are incompatible.
 *                Type '"ExactType"' is not assignable to type '"ReadonlyType"'.
 *
 *  17 const T123 = t.exact(t.intersection([T12, T3]));
 **/
```