### PR TITLE
Fixed intersection with inner exact of a empty interface

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -1827,7 +1827,7 @@ export const array = <C extends Mixed>(codec: C, name: string = `Array<${codec.n
     name,
     (u): u is Array<TypeOf<C>> => UnknownArray.is(u) && u.every(codec.is),
     (u, c) =>
-      chain(UnknownArray.validate(u, c), us => ...
+      UnknownArray.validate(u, c).chain(us => ...
 ```
 
 Added in v1.0.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -1168,19 +1168,14 @@ export interface IntersectionC<CS extends [Mixed, Mixed, ...Array<Mixed>]>
   > {}
 
 const mergeAll = (base: any, us: Array<any>): any => {
-  let r: any = base
-  for (let i = 0; i < us.length; i++) {
-    const u = us[i]
-    if (u !== base) {
-      // `u` contains a prismatic value or is the result of a stripping combinator
-      if (r === base) {
-        r = Object.assign({}, u)
-        continue
-      }
-      for (const k in u) {
-        if (u[k] !== base[k] || !r.hasOwnProperty(k)) {
-          r[k] = u[k]
-        }
+  if (!us.some(u => u !== base)) {
+    return base
+  }
+  const r: any = {}
+  for (const u of us) {
+    for (const k in u) {
+      if (!r.hasOwnProperty(k) || u[k] !== base[k]) {
+        r[k] = u[k]
       }
     }
   }

--- a/test/exact.ts
+++ b/test/exact.ts
@@ -51,6 +51,16 @@ describe('exact', () => {
       assertSuccess(T.decode({ foo: 'foo' }))
     })
 
+    it('should succeed validating a valid value (intersection with inner exact of a empty interface)', () => {
+      const T = t.intersection([
+        t.type({ foo: t.string }),
+        t.exact(t.intersection([t.interface({}), t.partial({ bar: t.number })]))
+      ])
+      assertSuccess(T.decode({ foo: 'foo', bar: 1 }))
+      assertSuccess(T.decode({ foo: 'foo', bar: undefined }))
+      assertSuccess(T.decode({ foo: 'foo' }), { foo: 'foo' })
+    })
+
     it('should succeed validating a valid value (refinement)', () => {
       // tslint:disable-next-line: deprecation
       const T = t.exact(t.refinement(t.type({ foo: t.string }), p => p.foo.length > 2))


### PR DESCRIPTION
The intersection decode operation will return an empty object when one of the input intersection element is an exect of an intersection of type without fields.
This issue is due to mergeAll function implementations: the empty type decode result will erroneus replace the return value (lines 1176 to 1179).
