### PR TITLE
Allow Error to be decoded with UnknownRecord 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -993,7 +993,7 @@ export class AnyDictionaryType extends Type<{ [key: string]: unknown }> {
       'UnknownRecord',
       (u): u is { [key: string]: unknown } => {
         const s = Object.prototype.toString.call(u)
-        return s === '[object Object]' || s === '[object Window]'
+        return s === '[object Object]' || s === '[object Window]' || s === '[object Error]'
       },
       (u, c) => (this.is(u) ? success(u) : failure(u, c)),
       identity

--- a/test/Type.ts
+++ b/test/Type.ts
@@ -84,11 +84,17 @@ describe('Type', () => {
     )
   })
 
-  it('UnknownRecord', () => {
-    check(
-      make((S) => S.UnknownRecord),
-      t.UnknownRecord
-    )
+  describe('UnknownRecord', () => {
+    test('UnknownRecord', () => {
+      check(
+        make((S) => S.UnknownRecord),
+        t.UnknownRecord
+      )
+    })
+
+    test('it can decode Error', () => {
+      assert.deepStrictEqual(isRight(_.UnknownRecord.decode(new Error())), true)
+    })
   })
 
   it('literal', () => {
@@ -206,6 +212,7 @@ describe('Type', () => {
     interface NonEmptyStringBrand {
       readonly NonEmptyString: unique symbol
     }
+
     type NonEmptyString = string & NonEmptyStringBrand
     const type = pipe(
       _.string,


### PR DESCRIPTION
Some libraries (e.g. AWS SDK, Axios) will throw Errors, but won't export the actual Error itself which prevents an  `e instanceof XError` check.

It's useful to be able to write a codec for these Errors, but no longer works after `2.0.5` ([previous implementation](https://github.com/gcanti/io-ts/blob/18e6437bbb9bc63c3ecfc6a1361eaa6250a9ce38/src/index.ts#L421)).

Related to issue #485.