### PR TITLE
Typo in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ A codec can:
 
 - decode inputs of type `I` (through `decode`)
 - encode outputs of type `O` (through `encode`)
-- be used as a custom [type guard](https://basarat.gitbooks.io/typescript/content/docs/types/typeGuard.html) (through `is`)
+- be used as a custom [type guard](https://basarat.gitbook.io/typescript/type-system/type-inference#type-guards) (through `is`)
 
 ```ts
 class Type<A, O, I> {

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ A codec can:
 
 - decode inputs of type `I` (through `decode`)
 - encode outputs of type `O` (through `encode`)
-- be used as a custom [type guard](https://basarat.gitbook.io/typescript/type-system/type-inference#type-guards) (through `is`)
+- be used as a custom [type guard](https://basarat.gitbook.io/typescript/type-system/typeguard) (through `is`)
 
 ```ts
 class Type<A, O, I> {


### PR DESCRIPTION
name: 📝 Documentation Fix
about: Fixing a problem in an existing docs page

## What is the problem?
Update refer link to `type guard`

## What changes does this PR make to fix the problem?
 be used as a custom [type guard](https://basarat.gitbook.io/typescript/type-system/type-inference#type-guards) (through `is`)
