### PR TITLE
Support readonly and/or non-empty arrays

### DIFF
--- a/docs/modules/Codec.ts.md
+++ b/docs/modules/Codec.ts.md
@@ -33,9 +33,12 @@ Added in v2.2.3
   - [intersect](#intersect)
   - [lazy](#lazy)
   - [mapLeftWithInput](#mapleftwithinput)
+  - [nonEmptyArray](#nonemptyarray)
   - [nullable](#nullable)
   - [partial](#partial)
   - [readonly](#readonly)
+  - [readonlyArray](#readonlyarray)
+  - [readonlyNonEmptyArray](#readonlynonemptyarray)
   - [record](#record)
   - [refine](#refine)
   - [struct](#struct)
@@ -216,6 +219,18 @@ export declare const mapLeftWithInput: <I>(
 
 Added in v2.2.3
 
+## nonEmptyArray
+
+**Signature**
+
+```ts
+export declare function nonEmptyArray<O, A>(
+  item: Codec<unknown, O, A>
+): Codec<unknown, NonEmptyArray<O>, NonEmptyArray<A>>
+```
+
+Added in v2.2.17
+
 ## nullable
 
 **Signature**
@@ -247,6 +262,30 @@ export declare const readonly: <I, O, A>(codec: Codec<I, O, A>) => Codec<I, O, R
 ```
 
 Added in v2.2.16
+
+## readonlyArray
+
+**Signature**
+
+```ts
+export declare function readonlyArray<O, A>(
+  item: Codec<unknown, O, A>
+): Codec<unknown, ReadonlyArray<O>, ReadonlyArray<A>>
+```
+
+Added in v2.2.17
+
+## readonlyNonEmptyArray
+
+**Signature**
+
+```ts
+export declare function readonlyNonEmptyArray<O, A>(
+  item: Codec<unknown, O, A>
+): Codec<unknown, ReadonlyNonEmptyArray<O>, ReadonlyNonEmptyArray<A>>
+```
+
+Added in v2.2.17
 
 ## record
 

--- a/docs/modules/Decoder.ts.md
+++ b/docs/modules/Decoder.ts.md
@@ -43,10 +43,13 @@ Added in v2.2.7
   - [intersect](#intersect)
   - [lazy](#lazy)
   - [mapLeftWithInput](#mapleftwithinput)
+  - [nonEmptyArray](#nonemptyarray)
   - [nullable](#nullable)
   - [parse](#parse)
   - [partial](#partial)
   - [readonly](#readonly)
+  - [readonlyArray](#readonlyarray)
+  - [readonlyNonEmptyArray](#readonlynonemptyarray)
   - [record](#record)
   - [refine](#refine)
   - [struct](#struct)
@@ -297,6 +300,16 @@ export declare const mapLeftWithInput: <I>(
 
 Added in v2.2.7
 
+## nonEmptyArray
+
+**Signature**
+
+```ts
+export declare const nonEmptyArray: <A>(item: Decoder<unknown, A>) => Decoder<unknown, NonEmptyArray<A>>
+```
+
+Added in v2.2.17
+
 ## nullable
 
 **Signature**
@@ -340,6 +353,26 @@ export declare const readonly: <I, A>(decoder: Decoder<I, A>) => Decoder<I, Read
 ```
 
 Added in v2.2.15
+
+## readonlyArray
+
+**Signature**
+
+```ts
+export declare const readonlyArray: <A>(item: Decoder<unknown, A>) => Decoder<unknown, readonly A[]>
+```
+
+Added in v2.2.17
+
+## readonlyNonEmptyArray
+
+**Signature**
+
+```ts
+export declare const readonlyNonEmptyArray: <A>(item: Decoder<unknown, A>) => Decoder<unknown, ReadonlyNonEmptyArray<A>>
+```
+
+Added in v2.2.17
 
 ## record
 

--- a/docs/modules/Encoder.ts.md
+++ b/docs/modules/Encoder.ts.md
@@ -29,9 +29,12 @@ Added in v2.2.3
   - [array](#array)
   - [intersect](#intersect)
   - [lazy](#lazy)
+  - [nonEmptyArray](#nonemptyarray)
   - [nullable](#nullable)
   - [partial](#partial)
   - [readonly](#readonly)
+  - [readonlyArray](#readonlyarray)
+  - [readonlyNonEmptyArray](#readonlynonemptyarray)
   - [record](#record)
   - [struct](#struct)
   - [sum](#sum)
@@ -118,6 +121,16 @@ export declare function lazy<O, A>(f: () => Encoder<O, A>): Encoder<O, A>
 
 Added in v2.2.3
 
+## nonEmptyArray
+
+**Signature**
+
+```ts
+export declare const nonEmptyArray: <O, A>(item: Encoder<O, A>) => Encoder<NonEmptyArray<O>, NonEmptyArray<A>>
+```
+
+Added in v2.2.17
+
 ## nullable
 
 **Signature**
@@ -149,6 +162,28 @@ export declare const readonly: <O, A>(decoder: Encoder<O, A>) => Encoder<O, Read
 ```
 
 Added in v2.2.16
+
+## readonlyArray
+
+**Signature**
+
+```ts
+export declare const readonlyArray: <O, A>(item: Encoder<O, A>) => Encoder<readonly O[], readonly A[]>
+```
+
+Added in v2.2.17
+
+## readonlyNonEmptyArray
+
+**Signature**
+
+```ts
+export declare const readonlyNonEmptyArray: <O, A>(
+  item: Encoder<O, A>
+) => Encoder<ReadonlyNonEmptyArray<O>, ReadonlyNonEmptyArray<A>>
+```
+
+Added in v2.2.17
 
 ## record
 

--- a/dtslint/ts3.5/Codec.ts
+++ b/dtslint/ts3.5/Codec.ts
@@ -65,6 +65,27 @@ _.fromArray(NumberFromString)
 _.array(_.string)
 
 //
+// readonlyArray
+//
+
+// $ExpectType Codec<unknown, ReadonlyArray<string>, ReadonlyArray<string>>
+_.readonlyArray(_.string)
+
+//
+// nonEmptyArray
+//
+
+// $ExpectType Codec<unknown, NonEmptyArray<string>, NonEmptyArray<string>>
+_.nonEmptyArray(_.string)
+
+//
+// readonlyNonEmptyArray
+//
+
+// $ExpectType Codec<unknown, ReadonlyNonEmptyArray<string>, ReadonlyNonEmptyArray<string>>
+_.readonlyNonEmptyArray(_.string)
+
+//
 // fromRecord
 //
 

--- a/dtslint/ts3.5/Decoder.ts
+++ b/dtslint/ts3.5/Decoder.ts
@@ -82,6 +82,27 @@ _.fromArray(NumberFromString)
 _.array(_.string)
 
 //
+// readonlyArray
+//
+
+// $ExpectType Decoder<unknown, ReadonlyArray<string>>
+_.readonlyArray(_.string)
+
+//
+// nonEmptyArray
+//
+
+// $ExpectType Decoder<unknown, NonEmptyArray<string>>
+_.nonEmptyArray(_.string)
+
+//
+// readonlyNonEmptyArray
+//
+
+// $ExpectType Decoder<unknown, ReadonlyNonEmptyArray<string>>
+_.readonlyNonEmptyArray(_.string)
+
+//
 // fromRecord
 //
 

--- a/dtslint/ts3.5/Encoder.ts
+++ b/dtslint/ts3.5/Encoder.ts
@@ -47,6 +47,21 @@ E.record(NumberToString) // $ExpectType Encoder<Record<string, string>, Record<s
 E.array(NumberToString) // $ExpectType Encoder<string[], number[]>
 
 //
+// readonlyArray
+//
+E.readonlyArray(NumberToString) // $ExpectType Encoder<ReadonlyArray<string>, ReadonlyArray<number>>
+
+//
+// nonEmptyArray
+//
+E.nonEmptyArray(NumberToString) // $ExpectType Encoder<NonEmptyArray<string>, NonEmptyArray<number>>
+
+//
+// readonlyNonEmptyArray
+//
+E.readonlyNonEmptyArray(NumberToString) // $ExpectType Encoder<ReadonlyNonEmptyArray<string>, ReadonlyNonEmptyArray<number>>
+
+//
 // tuple
 //
 E.tuple() // $ExpectType Encoder<[], []>

--- a/src/Codec.ts
+++ b/src/Codec.ts
@@ -10,6 +10,8 @@
  */
 import { identity, Refinement } from 'fp-ts/lib/function'
 import { Invariant3 } from 'fp-ts/lib/Invariant'
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import { ReadonlyNonEmptyArray } from 'fp-ts/lib/ReadonlyNonEmptyArray'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as D from './Decoder'
 import * as E from './Encoder'
@@ -218,6 +220,32 @@ export function fromArray<I, O, A>(item: Codec<I, O, A>): Codec<Array<I>, Array<
  */
 export function array<O, A>(item: Codec<unknown, O, A>): Codec<unknown, Array<O>, Array<A>> {
   return pipe(UnknownArray, compose(fromArray(item))) as any
+}
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export function readonlyArray<O, A>(item: Codec<unknown, O, A>): Codec<unknown, ReadonlyArray<O>, ReadonlyArray<A>> {
+  return make(D.readonlyArray(item), E.readonlyArray(item))
+}
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export function nonEmptyArray<O, A>(item: Codec<unknown, O, A>): Codec<unknown, NonEmptyArray<O>, NonEmptyArray<A>> {
+  return make(D.nonEmptyArray(item), E.nonEmptyArray(item))
+}
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export function readonlyNonEmptyArray<O, A>(
+  item: Codec<unknown, O, A>
+): Codec<unknown, ReadonlyNonEmptyArray<O>, ReadonlyNonEmptyArray<A>> {
+  return make(D.readonlyNonEmptyArray(item), E.readonlyNonEmptyArray(item))
 }
 
 /**

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -9,6 +9,10 @@
  * @since 2.2.7
  */
 import { Alt2, Alt2C } from 'fp-ts/lib/Alt'
+import * as A from 'fp-ts/lib/Array'
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import * as RA from 'fp-ts/lib/ReadonlyArray'
+import { ReadonlyNonEmptyArray } from 'fp-ts/lib/ReadonlyNonEmptyArray'
 import { Bifunctor2 } from 'fp-ts/lib/Bifunctor'
 import { Category2 } from 'fp-ts/lib/Category'
 import * as E from 'fp-ts/lib/Either'
@@ -291,6 +295,27 @@ export const fromArray = <I, A>(item: Decoder<I, A>): Decoder<Array<I>, Array<A>
  */
 export const array = <A>(item: Decoder<unknown, A>): Decoder<unknown, Array<A>> =>
   pipe(UnknownArray, compose(fromArray(item)))
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export const readonlyArray = <A>(item: Decoder<unknown, A>): Decoder<unknown, ReadonlyArray<A>> =>
+  pipe(array(item), readonly)
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export const nonEmptyArray = <A>(item: Decoder<unknown, A>): Decoder<unknown, NonEmptyArray<A>> =>
+  pipe(array(item), refine(A.isNonEmpty, 'NonEmptyArray<unknown>'))
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export const readonlyNonEmptyArray = <A>(item: Decoder<unknown, A>): Decoder<unknown, ReadonlyNonEmptyArray<A>> =>
+  pipe(readonlyArray(item), refine(RA.isNonEmpty, 'ReadonlyNonEmptyArray<unknown>'))
 
 /**
  * @category combinators

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -10,6 +10,8 @@
  */
 import { Contravariant2 } from 'fp-ts/lib/Contravariant'
 import { Category2 } from 'fp-ts/lib/Category'
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray'
+import { ReadonlyNonEmptyArray } from 'fp-ts/lib/ReadonlyNonEmptyArray'
 import { memoize, intersect_ } from './Schemable'
 import { identity } from 'fp-ts/lib/function'
 
@@ -114,6 +116,26 @@ export function array<O, A>(item: Encoder<O, A>): Encoder<Array<O>, Array<A>> {
     encode: (as) => as.map(item.encode)
   }
 }
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export const readonlyArray: <O, A>(item: Encoder<O, A>) => Encoder<ReadonlyArray<O>, ReadonlyArray<A>> = array as any
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export const nonEmptyArray: <O, A>(item: Encoder<O, A>) => Encoder<NonEmptyArray<O>, NonEmptyArray<A>> = array as any
+
+/**
+ * @category combinators
+ * @since 2.2.17
+ */
+export const readonlyNonEmptyArray: <O, A>(
+  item: Encoder<O, A>
+) => Encoder<ReadonlyNonEmptyArray<O>, ReadonlyNonEmptyArray<A>> = readonlyArray as any
 
 /**
  * @category combinators

--- a/test/Codec.ts
+++ b/test/Codec.ts
@@ -445,6 +445,114 @@ describe('Codec', () => {
     })
   })
 
+  describe('readonlyArray', () => {
+    describe('decode', () => {
+      it('should decode a valid input', () => {
+        const codec = _.readonlyArray(_.string)
+        assert.deepStrictEqual(codec.decode([]), D.success([]))
+        assert.deepStrictEqual(codec.decode(['a']), D.success(['a']))
+      })
+
+      it('should reject an invalid input', () => {
+        const codec = _.readonlyArray(_.string)
+        assert.deepStrictEqual(codec.decode(undefined), D.failure(undefined, 'Array<unknown>'))
+        assert.deepStrictEqual(codec.decode([1]), E.left(FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string'))))))
+      })
+
+      it('should collect all errors', () => {
+        const codec = _.readonlyArray(_.string)
+        assert.deepStrictEqual(
+          codec.decode([1, 2]),
+          E.left(
+            FS.concat(
+              FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string')))),
+              FS.of(DE.index(1, DE.optional, FS.of(DE.leaf(2, 'string'))))
+            )
+          )
+        )
+      })
+    })
+
+    describe('encode', () => {
+      it('should encode a value', () => {
+        const codec = _.readonlyArray(codecNumber)
+        assert.deepStrictEqual(codec.encode([1, 2]), ['1', '2'])
+      })
+    })
+  })
+
+  describe('nonEmptyArray', () => {
+    describe('decode', () => {
+      it('should decode a valid input', () => {
+        const codec = _.nonEmptyArray(_.string)
+        assert.deepStrictEqual(codec.decode(['a']), D.success(['a']))
+      })
+
+      it('should reject an invalid input', () => {
+        const codec = _.nonEmptyArray(_.string)
+        assert.deepStrictEqual(codec.decode(undefined), D.failure(undefined, 'Array<unknown>'))
+        assert.deepStrictEqual(codec.decode([]), D.failure([], 'NonEmptyArray<unknown>'))
+        assert.deepStrictEqual(codec.decode([1]), E.left(FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string'))))))
+      })
+
+      it('should collect all errors', () => {
+        const codec = _.nonEmptyArray(_.string)
+        assert.deepStrictEqual(
+          codec.decode([1, 2]),
+          E.left(
+            FS.concat(
+              FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string')))),
+              FS.of(DE.index(1, DE.optional, FS.of(DE.leaf(2, 'string'))))
+            )
+          )
+        )
+      })
+    })
+
+    describe('encode', () => {
+      it('should encode a value', () => {
+        const codec = _.nonEmptyArray(codecNumber)
+        assert.deepStrictEqual(codec.encode([1, 2]), ['1', '2'])
+      })
+    })
+  })
+
+  describe('readonlyNonEmptyArray', () => {
+    describe('decode', () => {
+      it('should decode a valid input', () => {
+        const codec = _.readonlyNonEmptyArray(_.string)
+        assert.deepStrictEqual(codec.decode(['a']), D.success(['a']))
+      })
+
+      it('should reject an invalid input', () => {
+        const codec = _.readonlyNonEmptyArray(_.string)
+        assert.deepStrictEqual(codec.decode(undefined), D.failure(undefined, 'Array<unknown>'))
+        assert.deepStrictEqual(codec.decode([]), D.failure([], 'ReadonlyNonEmptyArray<unknown>'))
+        assert.deepStrictEqual(codec.decode([1]), E.left(FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string'))))))
+      })
+
+      it('should collect all errors', () => {
+        const codec = _.readonlyNonEmptyArray(_.string)
+        assert.deepStrictEqual(
+          codec.decode([1, 2]),
+          E.left(
+            FS.concat(
+              FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string')))),
+              FS.of(DE.index(1, DE.optional, FS.of(DE.leaf(2, 'string'))))
+            )
+          )
+        )
+      })
+    })
+
+    describe('encode', () => {
+      it('should encode a value', () => {
+        const codec = _.readonlyNonEmptyArray(codecNumber)
+        assert.deepStrictEqual(codec.encode([1, 2]), ['1', '2'])
+      })
+    })
+  })
+
   describe('tuple', () => {
     describe('decode', () => {
       it('should decode a valid input', () => {

--- a/test/Decoder.ts
+++ b/test/Decoder.ts
@@ -291,6 +291,87 @@ describe('Decoder', () => {
     })
   })
 
+  describe('readonlyArray', () => {
+    it('should decode a valid input', async () => {
+      const decoder = _.readonlyArray(_.string)
+      assert.deepStrictEqual(decoder.decode([]), _.success([]))
+      assert.deepStrictEqual(decoder.decode(['a']), _.success(['a']))
+    })
+
+    it('should reject an invalid input', async () => {
+      const decoder = _.readonlyArray(_.string)
+      assert.deepStrictEqual(decoder.decode(undefined), E.left(FS.of(DE.leaf(undefined, 'Array<unknown>'))))
+      assert.deepStrictEqual(decoder.decode([1]), E.left(FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string'))))))
+    })
+
+    it('should collect all errors', async () => {
+      const decoder = _.readonlyArray(_.string)
+      assert.deepStrictEqual(
+        decoder.decode([1, 2]),
+        E.left(
+          FS.concat(
+            FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string')))),
+            FS.of(DE.index(1, DE.optional, FS.of(DE.leaf(2, 'string'))))
+          )
+        )
+      )
+    })
+  })
+
+  describe('nonEmptyArray', () => {
+    it('should decode a valid input', async () => {
+      const decoder = _.nonEmptyArray(_.string)
+      assert.deepStrictEqual(decoder.decode(['a']), _.success(['a']))
+    })
+
+    it('should reject an invalid input', async () => {
+      const decoder = _.nonEmptyArray(_.string)
+      assert.deepStrictEqual(decoder.decode(undefined), E.left(FS.of(DE.leaf(undefined, 'Array<unknown>'))))
+      assert.deepStrictEqual(decoder.decode([]), E.left(FS.of(DE.leaf([], 'NonEmptyArray<unknown>'))))
+      assert.deepStrictEqual(decoder.decode([1]), E.left(FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string'))))))
+    })
+
+    it('should collect all errors', async () => {
+      const decoder = _.nonEmptyArray(_.string)
+      assert.deepStrictEqual(
+        decoder.decode([1, 2]),
+        E.left(
+          FS.concat(
+            FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string')))),
+            FS.of(DE.index(1, DE.optional, FS.of(DE.leaf(2, 'string'))))
+          )
+        )
+      )
+    })
+  })
+
+  describe('readonlyNonEmptyArray', () => {
+    it('should decode a valid input', async () => {
+      const decoder = _.readonlyNonEmptyArray(_.string)
+      assert.deepStrictEqual(decoder.decode(['a']), _.success(['a']))
+    })
+
+    it('should reject an invalid input', async () => {
+      const decoder = _.readonlyNonEmptyArray(_.string)
+      assert.deepStrictEqual(decoder.decode(undefined), E.left(FS.of(DE.leaf(undefined, 'Array<unknown>'))))
+      assert.deepStrictEqual(decoder.decode([]), E.left(FS.of(DE.leaf([], 'ReadonlyNonEmptyArray<unknown>'))))
+      assert.deepStrictEqual(decoder.decode([1]), E.left(FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string'))))))
+    })
+
+    it('should collect all errors', async () => {
+      const decoder = _.readonlyNonEmptyArray(_.string)
+      assert.deepStrictEqual(
+        decoder.decode([1, 2]),
+        E.left(
+          FS.concat(
+            FS.of(DE.index(0, DE.optional, FS.of(DE.leaf(1, 'string')))),
+            FS.of(DE.index(1, DE.optional, FS.of(DE.leaf(2, 'string'))))
+          )
+        )
+      )
+    })
+  })
+
   describe('record', () => {
     it('should decode a valid value', async () => {
       const decoder = _.record(_.number)

--- a/test/Encoder.ts
+++ b/test/Encoder.ts
@@ -44,6 +44,21 @@ describe('Encoder', () => {
     assert.deepStrictEqual(encoder.encode([1, 2]), ['1', '2'])
   })
 
+  it('readonlyArray', () => {
+    const encoder = E.readonlyArray(H.encoderNumberToString)
+    assert.deepStrictEqual(encoder.encode([1, 2]), ['1', '2'])
+  })
+
+  it('nonEmptyArray', () => {
+    const encoder = E.nonEmptyArray(H.encoderNumberToString)
+    assert.deepStrictEqual(encoder.encode([1, 2]), ['1', '2'])
+  })
+
+  it('readonlyNonEmptyArray', () => {
+    const encoder = E.readonlyNonEmptyArray(H.encoderNumberToString)
+    assert.deepStrictEqual(encoder.encode([1, 2]), ['1', '2'])
+  })
+
   it('tuple', () => {
     const encoder = E.tuple(H.encoderNumberToString, H.encoderBooleanToNumber)
     assert.deepStrictEqual(encoder.encode([3, true]), ['3', 1])


### PR DESCRIPTION
This adds `readonlyArray`, `nonEmptyArray` and `readonlyNonEmptyArray` to the `Decoder`, `Encoder` and `Codec` modules, to match the various `fp-ts` array types.