### PR TITLE
Add tryCatch decoder

### DIFF
--- a/docs/modules/Decoder.ts.md
+++ b/docs/modules/Decoder.ts.md
@@ -70,6 +70,8 @@ Added in v2.2.7
   - [WithRefine](#withrefine)
   - [WithUnion](#withunion)
   - [WithUnknownContainers](#withunknowncontainers)
+- [interop](#interop)
+  - [tryCatch](#trycatch)
 - [model](#model)
   - [Decoder (interface)](#decoder-interface)
 - [primitives](#primitives)
@@ -577,6 +579,20 @@ export declare const WithUnknownContainers: S.WithUnknownContainers2C<'io-ts/Dec
 ```
 
 Added in v2.2.8
+
+# interop
+
+## tryCatch
+
+Constructs a new `Decoder` from a function that might throw.
+
+**Signature**
+
+```ts
+export declare const tryCatch: <I, A>(f: (i: I) => A, id: string) => Decoder<I, A>
+```
+
+Added in v2.2.17
 
 # model
 

--- a/docs/modules/TaskDecoder.ts.md
+++ b/docs/modules/TaskDecoder.ts.md
@@ -71,6 +71,8 @@ Added in v2.2.7
   - [WithRefine](#withrefine)
   - [WithUnion](#withunion)
   - [WithUnknownContainers](#withunknowncontainers)
+- [interop](#interop)
+  - [tryCatch](#trycatch)
 - [model](#model)
   - [TaskDecoder (interface)](#taskdecoder-interface)
 - [primitives](#primitives)
@@ -593,6 +595,20 @@ export declare const WithUnknownContainers: S.WithUnknownContainers2C<'io-ts/Tas
 ```
 
 Added in v2.2.8
+
+# interop
+
+## tryCatch
+
+Constructs a new `Decoder` from a function that returns a `Promise`.
+
+**Signature**
+
+```ts
+export declare const tryCatch: <I, A>(f: (i: I) => Promise<A>, id: string) => TaskDecoder<I, A>
+```
+
+Added in v2.2.17
 
 # model
 

--- a/dtslint/ts3.5/Decoder.ts
+++ b/dtslint/ts3.5/Decoder.ts
@@ -158,3 +158,10 @@ _.readonly(
     a: _.string
   })
 )
+
+//
+// tryCatch
+//
+
+// $ExpectType Decoder<string, number>
+_.tryCatch((a: string) => a.length, 'Length')

--- a/dtslint/ts3.5/TaskDecoder.ts
+++ b/dtslint/ts3.5/TaskDecoder.ts
@@ -22,3 +22,10 @@ _.readonly(
     a: _.string
   })
 )
+
+//
+// tryCatch
+//
+
+// $ExpectType TaskDecoder<string, number>
+_.tryCatch(async (a: string) => a.length, 'Length')

--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -381,6 +381,24 @@ export const lazy: <I, A>(id: string, f: () => Decoder<I, A>) => Decoder<I, A> =
 export const readonly: <I, A>(decoder: Decoder<I, A>) => Decoder<I, Readonly<A>> = identity
 
 // -------------------------------------------------------------------------------------
+// interop
+// -------------------------------------------------------------------------------------
+
+/**
+ * Constructs a new `Decoder` from a function that might throw.
+ *
+ * @category interop
+ * @since 2.2.17
+ */
+export const tryCatch: <I, A>(f: (i: I) => A, id: string) => Decoder<I, A> = (f, id) => ({
+  decode: (i) =>
+    E.tryCatch(
+      () => f(i),
+      () => error(i, id)
+    )
+})
+
+// -------------------------------------------------------------------------------------
 // non-pipeables
 // -------------------------------------------------------------------------------------
 

--- a/src/TaskDecoder.ts
+++ b/src/TaskDecoder.ts
@@ -387,6 +387,24 @@ export const lazy: <I, A>(id: string, f: () => TaskDecoder<I, A>) => TaskDecoder
 export const readonly: <I, A>(decoder: TaskDecoder<I, A>) => TaskDecoder<I, Readonly<A>> = identity
 
 // -------------------------------------------------------------------------------------
+// interop
+// -------------------------------------------------------------------------------------
+
+/**
+ * Constructs a new `Decoder` from a function that returns a `Promise`.
+ *
+ * @category interop
+ * @since 2.2.17
+ */
+export const tryCatch: <I, A>(f: (i: I) => Promise<A>, id: string) => TaskDecoder<I, A> = (f, id) => ({
+  decode: (i) =>
+    TE.tryCatch(
+      () => f(i),
+      () => error(i, id)
+    )
+})
+
+// -------------------------------------------------------------------------------------
 // non-pipeables
 // -------------------------------------------------------------------------------------
 

--- a/test/Decoder.ts
+++ b/test/Decoder.ts
@@ -530,6 +530,26 @@ describe('Decoder', () => {
   })
 
   // -------------------------------------------------------------------------------------
+  // interop
+  // -------------------------------------------------------------------------------------
+
+  describe('tryCatch', () => {
+    it('should decode when the function returns a value', () => {
+      const f = (value: number) => value + 1
+
+      assert.deepStrictEqual(_.tryCatch(f, 'Number').decode(1), _.success(2))
+    })
+
+    it('should reject when the function throws', () => {
+      const f = () => {
+        throw new Error('Some error')
+      }
+
+      assert.deepStrictEqual(_.tryCatch(f, 'Number').decode(1), E.left(FS.of(DE.leaf(1, 'Number'))))
+    })
+  })
+
+  // -------------------------------------------------------------------------------------
   // utils
   // -------------------------------------------------------------------------------------
 

--- a/test/TaskDecoder.ts
+++ b/test/TaskDecoder.ts
@@ -576,6 +576,26 @@ describe('UnknownTaskDecoder', () => {
   })
 
   // -------------------------------------------------------------------------------------
+  // interop
+  // -------------------------------------------------------------------------------------
+
+  describe('tryCatch', () => {
+    it('should decode when the promise resolves with a value', async () => {
+      const f = async (value: number) => value + 1
+
+      assert.deepStrictEqual(await _.tryCatch(f, 'Number').decode(1)(), D.success(2))
+    })
+
+    it('should reject when the promise rejects', async () => {
+      const f = async () => {
+        throw new Error('Some error')
+      }
+
+      assert.deepStrictEqual(await _.tryCatch(f, 'Number').decode(1)(), E.left(FS.of(DE.leaf(1, 'Number'))))
+    })
+  })
+
+  // -------------------------------------------------------------------------------------
   // utils
   // -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Helps to create a `Decoder` from a function that might throw, such as:

```ts
const UrlD: D.Decoder<unknown, URL> = pipe(D.string, D.compose(D.tryCatch(value => new URL(value))))
```