### PR TITLE
Treat struct properties that have type undefined as optional

### DIFF
--- a/docs/modules/Codec.ts.md
+++ b/docs/modules/Codec.ts.md
@@ -147,7 +147,11 @@ Added in v2.2.3
 ```ts
 export declare function fromStruct<P extends Record<string, Codec<any, any, any>>>(
   properties: P
-): Codec<{ [K in keyof P]: InputOf<P[K]> }, { [K in keyof P]: OutputOf<P[K]> }, { [K in keyof P]: TypeOf<P[K]> }>
+): Codec<
+  ToOptional<{ [K in keyof P]: InputOf<P[K]> }>,
+  ToOptional<{ [K in keyof P]: OutputOf<P[K]> }>,
+  ToOptional<{ [K in keyof P]: TypeOf<P[K]> }>
+>
 ```
 
 Added in v2.2.15
@@ -280,7 +284,7 @@ Added in v2.2.3
 ```ts
 export declare function struct<P extends Record<string, Codec<unknown, any, any>>>(
   properties: P
-): Codec<unknown, { [K in keyof P]: OutputOf<P[K]> }, { [K in keyof P]: TypeOf<P[K]> }>
+): Codec<unknown, ToOptional<{ [K in keyof P]: OutputOf<P[K]> }>, ToOptional<{ [K in keyof P]: TypeOf<P[K]> }>>
 ```
 
 Added in v2.2.15

--- a/docs/modules/Decoder.ts.md
+++ b/docs/modules/Decoder.ts.md
@@ -232,7 +232,21 @@ Added in v2.2.8
 ```ts
 export declare const fromStruct: <P extends Record<string, Decoder<any, any>>>(
   properties: P
-) => Decoder<{ [K in keyof P]: K.InputOf<'Either', P[K]> }, { [K in keyof P]: K.TypeOf<'Either', P[K]> }>
+) => Decoder<
+  { [K in keyof P]: K.InputOf<'Either', P[K]> },
+  Merge<
+    Pick<
+      { [K in keyof P]: K.TypeOf<'Either', P[K]> },
+      Exclude<keyof P, UndefinedProperties<{ [K in keyof P]: K.TypeOf<'Either', P[K]> }>>
+    > &
+      Partial<
+        Pick<
+          { [K in keyof P]: K.TypeOf<'Either', P[K]> },
+          UndefinedProperties<{ [K in keyof P]: K.TypeOf<'Either', P[K]> }>
+        >
+      >
+  >
+>
 ```
 
 Added in v2.2.15
@@ -371,7 +385,13 @@ Added in v2.2.7
 ```ts
 export declare const struct: <A>(
   properties: { [K in keyof A]: Decoder<unknown, A[K]> }
-) => Decoder<unknown, { [K in keyof A]: A[K] }>
+) => Decoder<
+  unknown,
+  Merge<
+    Pick<{ [K in keyof A]: A[K] }, Exclude<keyof A, UndefinedProperties<{ [K in keyof A]: A[K] }>>> &
+      Partial<Pick<{ [K in keyof A]: A[K] }, UndefinedProperties<{ [K in keyof A]: A[K] }>>>
+  >
+>
 ```
 
 Added in v2.2.15
@@ -433,7 +453,21 @@ Use `fromStruct` instead.
 ```ts
 export declare const fromType: <P extends Record<string, Decoder<any, any>>>(
   properties: P
-) => Decoder<{ [K in keyof P]: K.InputOf<'Either', P[K]> }, { [K in keyof P]: K.TypeOf<'Either', P[K]> }>
+) => Decoder<
+  { [K in keyof P]: K.InputOf<'Either', P[K]> },
+  Merge<
+    Pick<
+      { [K in keyof P]: K.TypeOf<'Either', P[K]> },
+      Exclude<keyof P, UndefinedProperties<{ [K in keyof P]: K.TypeOf<'Either', P[K]> }>>
+    > &
+      Partial<
+        Pick<
+          { [K in keyof P]: K.TypeOf<'Either', P[K]> },
+          UndefinedProperties<{ [K in keyof P]: K.TypeOf<'Either', P[K]> }>
+        >
+      >
+  >
+>
 ```
 
 Added in v2.2.8
@@ -447,7 +481,13 @@ Use `struct` instead.
 ```ts
 export declare const type: <A>(
   properties: { [K in keyof A]: Decoder<unknown, A[K]> }
-) => Decoder<unknown, { [K in keyof A]: A[K] }>
+) => Decoder<
+  unknown,
+  Merge<
+    Pick<{ [K in keyof A]: A[K] }, Exclude<keyof A, UndefinedProperties<{ [K in keyof A]: A[K] }>>> &
+      Partial<Pick<{ [K in keyof A]: A[K] }, UndefinedProperties<{ [K in keyof A]: A[K] }>>>
+  >
+>
 ```
 
 Added in v2.2.7

--- a/docs/modules/Encoder.ts.md
+++ b/docs/modules/Encoder.ts.md
@@ -167,7 +167,7 @@ Added in v2.2.3
 ```ts
 export declare function struct<P extends Record<string, Encoder<any, any>>>(
   properties: P
-): Encoder<{ [K in keyof P]: OutputOf<P[K]> }, { [K in keyof P]: TypeOf<P[K]> }>
+): Encoder<ToOptional<{ [K in keyof P]: OutputOf<P[K]> }>, { [K in keyof P]: TypeOf<P[K]> }>
 ```
 
 Added in v2.2.15

--- a/dtslint/ts3.5/Decoder.ts
+++ b/dtslint/ts3.5/Decoder.ts
@@ -3,6 +3,8 @@ import * as DE from '../../src/DecodeError'
 import * as _ from '../../src/Decoder'
 import * as FS from '../../src/FreeSemigroup'
 
+declare const Optional: <I, A>(decoder: _.Decoder<I, A>) => _.Decoder<I, A | undefined>
+
 declare const NumberFromString: _.Decoder<string, number>
 
 //
@@ -40,6 +42,14 @@ _.struct({
   a: _.string,
   b: _.struct({
     c: _.number
+  })
+})
+
+// $ExpectType Decoder<unknown, { b: { c?: number | undefined; }; a?: string | undefined; }>
+_.struct({
+  a: Optional(_.string),
+  b: _.struct({
+    c: Optional(_.number)
   })
 })
 
@@ -113,7 +123,7 @@ _.tuple(_.string, _.number, _.boolean)
 // fromSum
 //
 
-// $ExpectType Decoder<{ _tag: unknown; a: unknown; } | { _tag: unknown; b: string; }, { _tag: "A"; a: string; } | { _tag: "B"; b: number; }>
+// $ExpectType Decoder<{ _tag: unknown; a: unknown; } | { _tag: unknown; b: string; }, { a: string; _tag: "A"; } | { b: number; _tag: "B"; }>
 _.fromSum('_tag')({
   A: _.fromStruct({ _tag: _.literal('A'), a: _.string }),
   B: _.fromStruct({ _tag: _.literal('B'), b: NumberFromString })
@@ -126,7 +136,7 @@ _.fromSum('_tag')({
 const S1 = _.struct({ _tag: _.literal('A'), a: _.string })
 const S2 = _.struct({ _tag: _.literal('B'), b: _.number })
 
-// $ExpectType Decoder<unknown, { _tag: "A"; a: string; } | { _tag: "B"; b: number; }>
+// $ExpectType Decoder<unknown, { a: string; _tag: "A"; } | { b: number; _tag: "B"; }>
 _.sum('_tag')({ A: S1, B: S2 })
 // $ExpectError
 _.sum('_tag')({ A: S1, B: S1 })

--- a/dtslint/ts3.5/Encoder.ts
+++ b/dtslint/ts3.5/Encoder.ts
@@ -1,6 +1,8 @@
 import * as E from '../../src/Encoder'
 import { pipe } from 'fp-ts/lib/pipeable'
 
+declare const Optional: <O, A>(encoder: E.Encoder<O, A>) => E.Encoder<O | undefined, A | undefined>
+
 const NumberToString: E.Encoder<string, number> = {
   encode: String
 }
@@ -30,6 +32,7 @@ E.nullable(NumberToString) // $ExpectType Encoder<string | null, number | null>
 // struct
 //
 E.struct({ a: E.struct({ b: NumberToString }) }) // $ExpectType Encoder<{ a: { b: string; }; }, { a: { b: number; }; }>
+E.struct({ a: Optional(E.struct({ b: Optional(NumberToString) })) }) // $ExpectType Encoder<{ a?: { b?: string | undefined; } | undefined; }, { a: { b: number | undefined; } | undefined; }>
 
 //
 // partial
@@ -65,7 +68,7 @@ const S1 = E.struct({ _tag: E.id<'A'>(), a: NumberToString })
 const S2 = E.struct({ _tag: E.id<'B'>(), b: BooleanToNumber })
 const sum = E.sum('_tag')
 
-// $ExpectType Encoder<{ _tag: "A"; a: string; } | { _tag: "B"; b: number; }, { _tag: "A"; a: number; } | { _tag: "B"; b: boolean; }>
+// $ExpectType Encoder<{ a: string; _tag: "A"; } | { b: number; _tag: "B"; }, { _tag: "A"; a: number; } | { _tag: "B"; b: boolean; }>
 sum({ A: S1, B: S2 })
 
 const S3 = E.struct({ _tag: E.id<'C'>(), c: E.id<string>() })

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -45,14 +45,14 @@ export function nullable<O, A>(or: Encoder<O, A>): Encoder<null | O, null | A> {
  */
 export function struct<P extends Record<string, Encoder<any, any>>>(
   properties: P
-): Encoder<{ [K in keyof P]: OutputOf<P[K]> }, { [K in keyof P]: TypeOf<P[K]> }> {
+): Encoder<ToOptional<{ [K in keyof P]: OutputOf<P[K]> }>, { [K in keyof P]: TypeOf<P[K]> }> {
   return {
     encode: (a) => {
       const o: Record<keyof P, any> = {} as any
       for (const k in properties) {
         o[k] = properties[k].encode(a[k])
       }
-      return o
+      return o as any
     }
   }
 }
@@ -260,3 +260,10 @@ export type TypeOf<E> = E extends Encoder<any, infer A> ? A : never
  * @since 2.2.3
  */
 export type OutputOf<E> = E extends Encoder<infer O, any> ? O : never
+
+type UndefinedProperties<T> = {
+  [P in keyof T]-?: undefined extends T[P] ? P : never
+}[keyof T]
+type ToOptional<T> = Merge<Pick<T, Exclude<keyof T, UndefinedProperties<T>>> & Partial<Pick<T, UndefinedProperties<T>>>>
+type Identity<T> = T
+type Merge<T> = T extends any ? Identity<{ [k in keyof T]: T[k] }> : never


### PR DESCRIPTION
This is an attempt to fix https://github.com/gcanti/io-ts/pull/628#issuecomment-1084597642, by making properties in a `struct` that can have `undefined` as a value optional.

This feels quite thorny to do, and this is probably incomplete (e.g. `Schemeable`?).