### PR TITLE
Don't throw a TypeError when trying to decode a sum value that contains a dangerous string

### DIFF
--- a/src/Kleisli.ts
+++ b/src/Kleisli.ts
@@ -297,7 +297,7 @@ export function fromSum<M extends URIS2, E>(
     return {
       decode: (ir) => {
         const v: any = ir[tag]
-        if (v in members) {
+        if (Object.prototype.hasOwnProperty.call(members, v)) {
           return (members as any)[v].decode(ir)
         }
         return M.throwError(onTagError(tag, v, keys))

--- a/test/Decoder.ts
+++ b/test/Decoder.ts
@@ -461,6 +461,10 @@ describe('Decoder', () => {
         decoder.decode({ _tag: 'A', a: 1 }),
         E.left(FS.of(DE.key('a', DE.required, FS.of(DE.leaf(1, 'string')))))
       )
+      assert.deepStrictEqual(
+        decoder.decode({ _tag: 'toString', a: 1 }),
+        E.left(FS.of(DE.key('_tag', DE.required, FS.of(DE.leaf('toString', '"A" | "B"')))))
+      )
     })
 
     it('should support empty records', () => {


### PR DESCRIPTION
I've recently started to see sporadic test failures for https://github.com/PREreview/prereview.org/blob/f1909e23b7d8a27d1d97e922dbdffa42a5b84570/test/write-review.test.ts#L1560-L1617. The test is probably hard to follow, but it's failing when using https://github.com/PREreview/prereview.org/blob/f1909e23b7d8a27d1d97e922dbdffa42a5b84570/src/write-review.ts#L59-L67 to decode a value generated by `fc.record({ competingInterests: fc.string() }, { withDeletedKeys: true })`

The error is:

```
Stack trace: TypeError: members[v].decode is not a function

  at decode (node_modules/io-ts/lib/Kleisli.js:237:39)
```

A failing value looks like this:

```
{ competingInterests: 'toString' }
```

Fast-Check recently added a failure to generate strings containing JavaScript keywords and the like (https://github.com/dubzzz/fast-check/pull/3043), revealing that io-ts crashes when trying to decode a sum type as the 'in' operator finds inherited properties such as 'toString'.

I looked at using Fast-Check in the test, but it needs to be upgraded and causes its other usages to fail, so I've just used a built-in property name instead.