### PR TITLE
docs: remove david-dm.org from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![build status](https://img.shields.io/travis/gcanti/io-ts/master.svg?style=flat-square)](https://travis-ci.org/gcanti/io-ts)
-[![dependency status](https://img.shields.io/david/gcanti/io-ts.svg?style=flat-square)](https://david-dm.org/gcanti/io-ts)
 ![npm downloads](https://img.shields.io/npm/dm/io-ts.svg)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. The `david-dm.org` should be considered dead, thus badges should be removed from README.
