### PR TITLE
Added exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,18 @@
   "name": "io-ts",
   "version": "2.2.19",
   "description": "TypeScript runtime type system for IO decoding/encoding",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "require": "./lib/index.js",
+      "import": "./es6/index.js"
+    },
+    "./*": {
+      "types": "./lib/*.d.ts",
+      "require": "./lib/*.js",
+      "import": "./es6/*.js"
+    }
+  },
   "main": "lib/index.js",
   "module": "es6/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Needed to use `io-ts` in a package with `moduleResolution: NodeNext` in `tsconfig.json` so I added the exports field.

I'm currently using this fork and it's working fine.

Only `package.json` has been changed.