### PR TITLE
Add optional support to type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "jest": "25.2.7",
     "mocha": "7.1.1",
-    "prettier": "2.0.2",
+    "prettier": "^2.7.1",
     "rimraf": "3.0.2",
     "ts-jest": "25.3.1",
     "ts-node": "8.8.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,12 @@ export interface AnyProps {
 
 function getNameFromProps(props: Props): string {
   return Object.keys(props)
-    .map((k) => `${k}: ${props[k].name}`)
+    .map((k) => {
+      if (isOptional(props[k])) {
+        return `${k}?: ${props[k].name}`
+      }
+      return `${k}: ${props[k].name}`
+    })
     .join(', ')
 }
 
@@ -664,6 +669,10 @@ function isUnionC(codec: Any): codec is UnionC<[Mixed, Mixed, ...Array<Mixed>]> 
 
 function isRecursiveC(codec: Any): codec is RecursiveType<Any> {
   return (codec as any)._tag === 'RecursiveType'
+}
+
+function isOptional(codec: Any): codec is OptionalType {
+  return (codec as any)._tag === 'OptionalType'
 }
 
 const lazyCodecs: Array<Any> = []
@@ -1320,11 +1329,29 @@ export class InterfaceType<P, A = any, O = A, I = unknown> extends Type<A, O, I>
   }
 }
 
+type TypeOfWithOptionalProps<P extends AnyProps> = (
+  {
+    [K in keyof P]?: TypeOf<P[K]>
+  } &
+  {
+    [K in keyof P as P[K] extends OptionalType ? never : K]-?: TypeOf<P[K]>
+  }
+)
+
+type OutputOfWithOptionalProps<P extends AnyProps> = (
+  {
+    [K in keyof P]?: OutputOf<P[K]>
+  } &
+  {
+    [K in keyof P as P[K] extends OptionalType<any> ? never : K]-?: OutputOf<P[K]>
+  }
+)
+
 /**
  * @since 1.5.3
  */
 export interface TypeC<P extends Props>
-  extends InterfaceType<P, { [K in keyof P]: TypeOf<P[K]> }, { [K in keyof P]: OutputOf<P[K]> }, unknown> {}
+  extends InterfaceType<P, TypeOfWithOptionalProps<P>, OutputOfWithOptionalProps<P>, unknown> {}
 
 /**
  * @category combinators
@@ -1341,7 +1368,9 @@ export function type<P extends Props>(props: P, name: string = getInterfaceTypeN
         for (let i = 0; i < len; i++) {
           const k = keys[i]
           const uk = u[k]
-          if ((uk === undefined && !hasOwnProperty.call(u, k)) || !types[i].is(uk)) {
+          if (uk === undefined && !hasOwnProperty.call(u, k)) {
+            return isOptional(props[k])
+          } else if (!types[i].is(uk)) {
             return false
           }
         }
@@ -1366,7 +1395,7 @@ export function type<P extends Props>(props: P, name: string = getInterfaceTypeN
           pushAll(errors, result.left)
         } else {
           const vak = result.right
-          if (vak !== ak || (vak === undefined && !hasOwnProperty.call(a, k))) {
+          if (vak !== ak || (vak === undefined && !hasOwnProperty.call(a, k) && !isOptional(type))) {
             /* istanbul ignore next */
             if (a === o) {
               a = { ...o }
@@ -1384,13 +1413,53 @@ export function type<P extends Props>(props: P, name: string = getInterfaceTypeN
           for (let i = 0; i < len; i++) {
             const k = keys[i]
             const encode = types[i].encode
-            if (encode !== identity) {
-              s[k] = encode(a[k])
+            const av = a[k]
+            if (encode !== identity && (av !== undefined || !isOptional(types[i]))) {
+              s[k] = encode(av)
             }
           }
           return s as any
         },
     props
+  )
+}
+
+export class OptionalType<A = any, O = A, I = unknown> extends Type<A, O, I> {
+  constructor(name: string,
+              is: OptionalType<A, O, I>['is'],
+              validate: OptionalType<A, O, I>['validate'],
+              encode: OptionalType<A, O, I>['encode'],
+              codec: Type<A, O, I>) {
+    super(name, is, validate, encode)
+    this._type = codec
+  }
+
+  readonly _type: Type<A, O, I>
+  readonly _tag: 'OptionalType' = 'OptionalType'
+}
+
+export function optional<A, O = A, I = unknown>(
+  codec: Type<A, O, I>,
+  name?: string
+): OptionalType<A, O, I> {
+  return new OptionalType<A, O, I>(
+    name || codec.name,
+    codec.is,
+    (u, c) => {
+      if (u === undefined) {
+        return success(undefined as A)
+      }
+      return codec.validate(u, c)
+    },
+    codec.encode === identity
+      ? identity
+      : (u) => {
+        if (u === undefined) {
+          return undefined as any
+        }
+        return codec.encode(u)
+      },
+    codec
   )
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1329,7 +1329,7 @@ export class InterfaceType<P, A = any, O = A, I = unknown> extends Type<A, O, I>
   }
 }
 
-type TypeOfWithOptionalProps<P extends AnyProps> = (
+export type TypeOfWithOptionalProps<P extends AnyProps> = (
   {
     [K in keyof P]?: TypeOf<P[K]>
   } &
@@ -1338,7 +1338,7 @@ type TypeOfWithOptionalProps<P extends AnyProps> = (
   }
 )
 
-type OutputOfWithOptionalProps<P extends AnyProps> = (
+export type OutputOfWithOptionalProps<P extends AnyProps> = (
   {
     [K in keyof P]?: OutputOf<P[K]>
   } &
@@ -1451,14 +1451,7 @@ export function optional<A, O = A, I = unknown>(
       }
       return codec.validate(u, c)
     },
-    codec.encode === identity
-      ? identity
-      : (u) => {
-        if (u === undefined) {
-          return undefined as any
-        }
-        return codec.encode(u)
-      },
+    codec.encode,
     codec
   )
 }

--- a/test/2.1.x/optional.ts
+++ b/test/2.1.x/optional.ts
@@ -1,0 +1,274 @@
+import * as assert from 'assert'
+import { fold } from 'fp-ts/lib/Either'
+import { pipe } from 'fp-ts/lib/pipeable'
+import * as t from '../../src/index'
+import { assertFailure, assertStrictEqual, assertSuccess, NumberFromString, withDefault } from './helpers'
+
+describe('type', () => {
+  describe('name', () => {
+    it('should assign a default name', () => {
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assert.strictEqual(T.name, '{ a: string, b?: string }')
+    })
+
+    it('should accept a name', () => {
+      const T = t.type({ a: t.string }, 'T')
+      assert.strictEqual(T.name, 'T')
+    })
+  })
+
+  describe('is', () => {
+    it('should return `true` on valid inputs', () => {
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assert.strictEqual(T.is({ a: 'a' }), true)
+      assert.strictEqual(T.is({ a: 'a', b: 'b' }), true)
+    })
+
+    it('should return `false` on invalid inputs', () => {
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assert.strictEqual(T.is({}), false)
+      assert.strictEqual(T.is({ a: 1 }), false)
+      assert.strictEqual(T.is({ b: 'b' }), false)
+      assert.strictEqual(T.is([]), false)
+    })
+
+    it('should return `false` on missing fields', () => {
+      const T = t.type({ a: t.unknown })
+      assert.strictEqual(T.is({}), false)
+    })
+
+    it('should allow additional properties', () => {
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assert.strictEqual(T.is({ a: 'a', b: 'b', c: 'c' }), true)
+    })
+
+    it('should work for classes with getters', () => {
+      class A {
+        get a() {
+          return 'a'
+        }
+        get b() {
+          return 'b'
+        }
+      }
+      class B {
+        get a() {
+          return 'a'
+        }
+      }
+      class C {
+        get b() {
+          return 'b'
+        }
+      }
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assert.strictEqual(T.is(new A()), true)
+      assert.strictEqual(T.is(new B()), true)
+      assert.strictEqual(T.is(new C()), false)
+    })
+  })
+
+  describe('decode', () => {
+    it('should decode a isomorphic value', () => {
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assertSuccess(T.decode({ a: 'a' }))
+      assertSuccess(T.decode({ a: 'a', b: 'b' }))
+    })
+
+    it('should decode a prismatic value', () => {
+      const T = t.type({ a: NumberFromString, b: t.optional(NumberFromString) })
+      assertSuccess(T.decode({ a: '1' }), { a: 1 })
+      assertSuccess(T.decode({ a: '1', b: '2' }), { a: 1, b: 2 })
+    })
+
+    it('should decode undefined properties as always present keys when required', () => {
+      const T1 = t.type({ a: t.undefined })
+      assertSuccess(T1.decode({ a: undefined }), { a: undefined })
+      assertSuccess(T1.decode({}), { a: undefined })
+
+      const T2 = t.type({ a: t.union([t.number, t.undefined]) })
+      assertSuccess(T2.decode({ a: undefined }), { a: undefined })
+      assertSuccess(T2.decode({ a: 1 }), { a: 1 })
+      assertSuccess(T2.decode({}), { a: undefined })
+
+      const T3 = t.type({ a: t.unknown })
+      assertSuccess(T3.decode({}), { a: undefined })
+    })
+
+    it('should decode undefined properties as missing keys when optional and omitted', () => {
+      const T1 = t.type({ a: t.optional(t.undefined) })
+      assertSuccess(T1.decode({ a: undefined }), { a: undefined })
+      assertSuccess(T1.decode({}), {})
+
+      const T2 = t.type({ a: t.optional(t.union([t.number, t.undefined])) })
+      assertSuccess(T2.decode({ a: undefined }), { a: undefined })
+      assertSuccess(T2.decode({ a: 1 }), { a: 1 })
+      assertSuccess(T2.decode({}), {})
+
+      const T3 = t.type({ a: t.optional(t.unknown) })
+      assertSuccess(T3.decode({}), {})
+    })
+
+    it('should fail decoding an invalid value', () => {
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assertFailure(T, 1, ['Invalid value 1 supplied to : { a: string, b?: string }'])
+      assertFailure(T, {}, ['Invalid value undefined supplied to : { a: string, b?: string }/a: string'])
+      assertFailure(T, { a: 1 }, ['Invalid value 1 supplied to : { a: string, b?: string }/a: string'])
+      assertFailure(T, [], ['Invalid value [] supplied to : { a: string, b?: string }'])
+    })
+
+    it('#423', () => {
+      class A {
+        get a() {
+          return 'a'
+        }
+        get b() {
+          return 'b'
+        }
+      }
+      const T = t.type({ a: t.string, b: t.string })
+      assertSuccess(T.decode(new A()))
+    })
+
+    it('should support default values', () => {
+      const T = t.type({
+        name: withDefault(t.string, 'foo')
+      })
+      assertSuccess(T.decode({}), { name: 'foo' })
+      assertSuccess(T.decode({ name: 'a' }), { name: 'a' })
+    })
+  })
+
+  describe('encode', () => {
+    it('should encode a isomorphic value', () => {
+      const T = t.type({ a: t.string, b: t.optional(t.string) })
+      assert.deepStrictEqual(T.encode({ a: 'a' }), { a: 'a' })
+      assert.deepStrictEqual(T.encode({ a: 'a', b: 'b' }), { a: 'a', b: 'b' })
+    })
+
+    it('should encode a prismatic value', () => {
+      const T = t.type({ a: NumberFromString, b: t.optional(NumberFromString) })
+      assert.deepStrictEqual(T.encode({ a: 1 }), { a: '1' })
+      assert.deepStrictEqual(T.encode({ a: 1, b: 2 }), { a: '1', b: '2' })
+    })
+  })
+
+  it('should keep unknown properties', () => {
+    const T = t.type({ a: t.string })
+    const validation = T.decode({ a: 's', b: 1 })
+    pipe(
+      validation,
+      fold(
+        () => {
+          assert.ok(false)
+        },
+        (a) => {
+          assert.deepStrictEqual(a, { a: 's', b: 1 })
+        }
+      )
+    )
+  })
+
+  it('should return the same reference if validation succeeded and nothing changed', () => {
+    const T = t.type({ a: t.string, b: t.optional(t.string) })
+    const value1 = { a: 's' }
+    assertStrictEqual(T.decode(value1), value1)
+    const value2 = { a: 's', b: 't' }
+    assertStrictEqual(T.decode(value2), value2)
+  })
+
+  it('should return the same reference while encoding', () => {
+    const T = t.type({ a: t.string, b: t.optional(t.string) })
+    assert.strictEqual(T.encode, t.identity)
+  })
+
+  it('should work for empty object', () => {
+    const T = t.type({})
+    assert.deepStrictEqual(T.encode({}), {})
+    assert.deepStrictEqual(T.decode({}), t.success({}))
+    assert.strictEqual(T.is({}), true)
+  })
+
+  it('should work for an object with all required properties', () => {
+    const type = t.type({
+      p1: t.string,
+      p2: t.string,
+      p3: t.optional(t.string)
+    })
+    const obj = {
+      p1: 'p1',
+      p2: 'p2',
+      p3: 'p3'
+    }
+    assert.deepStrictEqual(type.encode(obj), {
+      p1: 'p1',
+      p2: 'p2',
+      p3: 'p3'
+    })
+    assert.deepStrictEqual(
+      type.decode(obj),
+      t.success({
+        p1: 'p1',
+        p2: 'p2',
+        p3: 'p3'
+      })
+    )
+    assert.strictEqual(type.is(obj), true)
+    assert.strictEqual(type.is({}), false)
+    assert.strictEqual(type.is({ p1: 'p1' }), false)
+  })
+
+  it('should work for an object with all optional properties', () => {
+    const type = t.type(
+      {
+        p1: t.optional(t.string),
+        p2: t.optional(t.string)
+      },
+      'Required'
+    )
+    const obj = {
+      p1: 'p1',
+      p2: 'p2'
+    }
+    assert.deepStrictEqual(type.encode(obj), {
+      p1: 'p1',
+      p2: 'p2'
+    })
+    assert.deepStrictEqual(
+      type.decode(obj),
+      t.success({
+        p1: 'p1',
+        p2: 'p2'
+      })
+    )
+    assert.strictEqual(type.is(obj), true)
+    assert.strictEqual(type.is({}), true)
+    assert.strictEqual(type.is({ p1: 'p1' }), true)
+  })
+
+  it('should work for an object with a mix of optional and required props', () => {
+    const type = t.type(
+      {
+        p1: t.string,
+        p2: t.optional(t.string),
+        p3: t.string,
+        p4: t.optional(t.string)
+      },
+      'Required'
+    )
+    const obj = {
+      p1: 'p1',
+      p2: 'p2',
+      p3: 'p3',
+      p4: 'p4'
+    }
+    expect(type.encode(obj)).toEqual(obj)
+    expect(type.decode(obj)).toEqual(t.success(obj))
+    assert.strictEqual(type.is(obj), true)
+    assert.strictEqual(type.is({}), false)
+    assert.strictEqual(type.is({ p1: 'p1', p2: 'p2' }), false)
+    assert.strictEqual(type.is({ p2: 'p2', p4: 'p4' }), false)
+    assert.strictEqual(type.is({ p1: 'p1', p3: 'p3' }), true)
+    assert.strictEqual(type.is({ p1: 'p1', p2: 'p2', p3: 'p3' }), true)
+  })
+})

--- a/test/2.1.x/strictInterfaceWithOptionals.ts
+++ b/test/2.1.x/strictInterfaceWithOptionals.ts
@@ -6,7 +6,7 @@ export function strictInterfaceWithOptionals<R extends t.Props, O extends t.Prop
   required: R,
   optional: O,
   name?: string
-): t.Type<t.TypeOfProps<R> & t.TypeOfPartialProps<O>, t.OutputOfProps<R> & t.OutputOfPartialProps<O>> {
+): t.Type<t.TypeOfWithOptionalProps<R> & t.TypeOfPartialProps<O>, t.OutputOfWithOptionalProps<R> & t.OutputOfPartialProps<O>> {
   return t.exact(t.intersection([t.type(required), t.partial(optional)]), name)
 }
 


### PR DESCRIPTION
Based on the [PR #654](https://github.com/gcanti/io-ts/pull/654) , I'm trying to make a more readable solution to support optional properties of TypeScript.

```typescript
const TypeA = t.type({
  propA: t.optional(t.string),
  propB: t.string
})
```

I define a new keyword `t.optional` to annotate a properties is optional. The above declaration will generated type like following:
```typescript
interface TypeA {
  propA?: string;
  propB: string;
}
```

I borrow all UT from the PR #654 . Thanks to the author @mjburghoffer, your UT help me so many.

BTW, I don't known why I cannot pass all test (prettier and eslint) on my local environment. If it's a problem to merge this PR. let me known, I will take more research for it.