### PR TITLE
reorder documentation to make it more beginner-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ npm i io-ts fp-ts
 
 # Usage
 
+
 ## Stable features
 
-- [`index.ts` module](index.md)
+- [Documentation of the main stable features (`index.ts` module)](index.md)
 
 ## Experimental modules (version `2.2+`)
 


### PR DESCRIPTION
This adds a full (validation) example to the beginning of index.md, and moves the combinators table up a bit.

I think there's more improvements that could be done, but this is a start.

tbh I'm not sure if I modified the right file because docs/index.md also exist but I don't think is used / referenced anywhere?

Relevant issue: https://github.com/gcanti/io-ts/issues/468