### PR TITLE
Providing a way to replace the failure implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,8 +63,8 @@ export const failures: <T>(errors: Errors) => Validation<T> = left
 export let failure = <T>(value: unknown, context: Context, message?: string): Validation<T> =>
   failures([{ value, context, message }])
 
-export const setFailureImplementation = <T>(impl: (value: unknown, context: Context, message?: string) => Validation<T>): void => {
-  failure = impl
+export const setFailureImplementation = (impl: (value: unknown, context: Context, message?: string) => Validation<unknown>): void => {
+  failure = (impl as any)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,12 @@ export const failures: <T>(errors: Errors) => Validation<T> = left
  * @category Decode error
  * @since 1.0.0
  */
-export const failure = <T>(value: unknown, context: Context, message?: string): Validation<T> =>
+export let failure = <T>(value: unknown, context: Context, message?: string): Validation<T> =>
   failures([{ value, context, message }])
+
+export const setFailureImplementation = <T>(impl: (value: unknown, context: Context, message?: string) => Validation<T>): void => {
+  failure = impl
+}
 
 /**
  * @category Decode error


### PR DESCRIPTION
**Description**

The given PR provides a way to replace the `failure` implementation used by the built-in codecs, like, `t.string` etc.

**Goal**

We want to use the current full-featured validation in the dev environment, but in the production we want to just log errors and go ahead "as is".

So the idea is to have an option to change the validation behaviour with a code like this.

```typescript
import {success, setFailureImplementation} from ''

if (process.env.NODE_ENV !== 'development') {
  setFailureImplementation(value, context, message) => { 
    Logger.logError(context, message)
    return success(value)
  }
}
```

<hr />

Please feel free to add your feedback, I'll do my best to fine-tune my PR>