### PR TITLE
Handle `record` keys outside `domain`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1961,7 +1961,7 @@ export function exact<C extends HasProps>(codec: C, name: string = getExactTypeN
       }
       return right(stripKeys(ce.right, props))
     },
-    useIdentity(Object.values(props)) ? (a) => stripKeys(a, props) : (a) => codec.encode(stripKeys(a, props)),
+    (a) => codec.encode(stripKeys(a, props)),
     codec
   )
 }

--- a/test/2.1.x/helpers.ts
+++ b/test/2.1.x/helpers.ts
@@ -83,13 +83,19 @@ export const NumberFromString = new t.Type<number, string, unknown>(
   String
 )
 
-export const HyphenatedString = new t.Type<string, string, unknown>(
-  'HyphenatedString',
-  (v): v is string => t.string.is(v) && v.length === 3 && v[1] === '-',
+export const HyphenatedString = t.refinement(
+  t.string,
+  (v): v is `${string}-${string}` => v.length === 3 && v[1] === '-',
+  '`${string}-${string}`'
+)
+
+export const HyphenatedStringFromNonHyphenated = new t.Type<`${string}-${string}`, string, unknown>(
+  'HyphenatedStringFromNonHyphenated',
+  HyphenatedString.is,
   (u, c) =>
     either.chain(t.string.validate(u, c), (s) => {
       if (s.length === 2) {
-        return right(s[0] + '-' + s[1])
+        return right(`${s[0]}-${s[1]}` as const)
       } else {
         return t.failure(s, c)
       }


### PR DESCRIPTION
Addresses #704.

New behavior is that:
- `record.is` allows keys outside `domain`
- `record.{en,de}code` allow but strip keys outside `domain`

Other changes:
- added/modified appropriate `record` tests
  - distinguished `HyphenatedString` from `HyphenatedStringFromNonHyphenated` so that the former can be used for (only) testing a `domain` that is a subset of `string`, and the latter for testing a prismatic `domain`
- implement `enumerableRecord` in terms of `exact`

Happy to iterate based on feedback.
